### PR TITLE
Adding VIP interface option

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -2,30 +2,32 @@
 #
 # === Parameters:
 #
-# $interface::          Define which interface to listen on.
+# $interface::             Define which interface to listen on.
 #
-# $priority::           Set instance priority.
+# $priority::              Set instance priority.
 #
-# $state::              Set instance state.
-#                       Valid options: MASTER, BACKUP.
+# $state::                 Set instance state.
+#                          Valid options: MASTER, BACKUP.
 #
-# $virtual_ipaddress::  Set floating IP address.
+# $virtual_ipaddress_int:: Set interface for VIP to be assigned to, defaults to $interfac
 #
-# $virtual_router_id::  Set virtual router id.
+# $virtual_ipaddress::     Set floating IP address.
 #
-# $ensure::             Default: present.
+# $virtual_router_id::     Set virtual router id.
 #
-# $auth_type::          Set authentication method.
-#                       Default: undef.
+# $ensure::                Default: present.
 #
-# $auth_pass::          Authentication password.
-#                       Default: undef.
+# $auth_type::             Set authentication method.
+#                          Default: undef.
 #
-# $track_script::       Define which script to run to track service states.
-#                       Default: undef.
+# $auth_pass::             Authentication password.
+#                          Default: undef.
 #
-# $lvs_interface::      Define lvs_sync_daemon_interface.
-#                       Default: undef.
+# $track_script::          Define which script to run to track service states.
+#                          Default: undef.
+#
+# $lvs_interface::         Define lvs_sync_daemon_interface.
+#                          Default: undef.
 #
 define keepalived::vrrp::instance (
   $interface,
@@ -33,11 +35,12 @@ define keepalived::vrrp::instance (
   $state,
   $virtual_ipaddress,
   $virtual_router_id,
-  $ensure        = present,
-  $auth_type     = undef,
-  $auth_pass     = undef,
-  $track_script  = undef,
-  $lvs_interface = undef,
+  $ensure                = present,
+  $auth_type             = undef,
+  $auth_pass             = undef,
+  $track_script          = undef,
+  $lvs_interface         = undef,
+  $virtual_ipaddress_int = undef,
 ) {
   concat::fragment { "keepalived.conf_vrrp_instance_${name}":
     ensure  => $ensure,

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -228,4 +228,26 @@ describe 'keepalived::vrrp::instance', :type => :define do
       )
     }
   end
+
+  describe 'with parameter virtual_ipaddress_int' do
+    let (:title) { '_NAME_' }
+    let (:params) {
+      {
+        :virtual_ipaddress_int => '_VALUE_',
+        :interface => '',
+        :priority => '',
+        :state => '',
+        :virtual_ipaddress => ['192.168.1.1'],
+        :virtual_router_id => ''
+      }
+    }
+
+    it { should create_keepalived__vrrp__instance('_NAME_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /192.168.1.1 dev _VALUE_/
+      )
+    }
+    end
 end

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -20,9 +20,16 @@ vrrp_instance <%= @name %> {
   }
   <% else %>
   <% end %>
+  <% if @virtual_ipaddress_int %>
+  virtual_ipaddress {
+    <% @virtual_ipaddress.each do |ip| %><%= ip %> dev <%= @virtual_ipaddress_int %>
+  }
+  <% end %>
+  <% else %>
   virtual_ipaddress {
     <% @virtual_ipaddress.each do |ip| %><%= ip %> dev <%= @interface %>
     <% end %>
   }
+  <% end %>
 }
 


### PR DESCRIPTION
Allow the virutal_ipaddress to live on a different interface than on where vrrp runs on.  Useful for setting up keepalived on cloud providers that require GRE tunnels for multicast traffic.
