### PR TITLE
Fewer empty lines in vrrp instances

### DIFF
--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -6,8 +6,8 @@ vrrp_instance <%= @name %> {
   <%- if @lvs_interface -%>
   lvs_sync_daemon_interface <%= @lvs_interface %>
   <%- end -%>
-
   <%- if @auth_type -%>
+
   authentication {
     auth_type <%= @auth_type %>
     auth_pass <%= @auth_pass %>


### PR DESCRIPTION
Particularly with larger configs I find the keepalived.conf easier to read with fewer empty lines, since more of it fits on one screen.

This removes the leading/trailing space from around erb tags and then places empty lines only if optional sections are used.

I find the result better, but you might decide it's not worth restarting keepalived for :)
