### PR TITLE
Stop 'invalid interval' messages in ruby 1.8

### DIFF
--- a/spec/classes/keepalived_global_defs_spec.rb
+++ b/spec/classes/keepalived_global_defs_spec.rb
@@ -19,7 +19,7 @@ describe 'keepalived::global_defs', :type => :class do
     it {
       should \
         contain_concat__fragment('keepalived.conf_globaldefs').with(
-        'content' => /notification_email\n\s*{\n\s*_VALUE_/
+        'content' => /notification_email\n\s*\{\n\s*_VALUE_/
       )
     }
   end
@@ -34,7 +34,7 @@ describe 'keepalived::global_defs', :type => :class do
     it {
       should \
         contain_concat__fragment('keepalived.conf_globaldefs').with(
-        'content' => /notification_email\n\s*{\n\s*_VALUE1_\n\s*_VALUE2_/
+        'content' => /notification_email\n\s*\{\n\s*_VALUE1_\n\s*_VALUE2_/
       )
     }
   end

--- a/spec/defines/keepalived_vrrp_sync_group_spec.rb
+++ b/spec/defines/keepalived_vrrp_sync_group_spec.rb
@@ -24,7 +24,7 @@ describe 'keepalived::vrrp::sync_group', :type => :define do
     it {
       should \
         contain_concat__fragment('keepalived.conf_vrrp_sync_group__NAME_').with(
-          'content' => /group {\n\s.*_VALUE_/
+          'content' => /group \{\n\s.*_VALUE_/
       )
     }
   end
@@ -41,7 +41,7 @@ describe 'keepalived::vrrp::sync_group', :type => :define do
     it {
       should \
         contain_concat__fragment('keepalived.conf_vrrp_sync_group__NAME_').with(
-          'content' => /group {\n\s.*_VALUE1_\n\s.*_VALUE2_/
+          'content' => /group \{\n\s.*_VALUE1_\n\s.*_VALUE2_/
       )
     }
   end


### PR DESCRIPTION
ruby 1.8 doesn't like unescaped curly braces
