### PR TITLE
Use released versions of dependencies for specs.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,11 @@
 fixtures:
   repositories:
-    concat: 'git://github.com/ripienaar/puppet-concat.git'
-    stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+    concat: 
+      repo: 'git://github.com/puppetlabs/puppetlabs-concat.git'
+      ref:  '1.0.0'
+    stdlib: 
+      repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+      ref:  '3.2.0'
 
   symlinks:
     keepalived: "#{source_dir}"


### PR DESCRIPTION
So that upstream breakages/changes don't cause spurious test failures.

The specs are failing for me right now due to the problem described in https://github.com/puppetlabs/puppetlabs-concat/pull/81
