### PR TITLE
LVS support, an initial cut

### DIFF
--- a/manifests/lvs/virtual_server.pp
+++ b/manifests/lvs/virtual_server.pp
@@ -61,10 +61,10 @@
 #
 # [*real_servers*]
 #   The real servers to balance to.
-#   A hash (single real server) or an array of hashes.
+#   An array of hashes.
 #   Hash keys:
 #     [*ip_address*]
-#     [*port*]
+#     [*port*]       (if ommitted the port defaults to the VIP port)
 # 
 define keepalived::lvs::virtual_server (
   $ip_address,

--- a/spec/defines/keepalived_lvs_virtual_server_spec.rb
+++ b/spec/defines/keepalived_lvs_virtual_server_spec.rb
@@ -199,6 +199,24 @@ describe 'keepalived::lvs::virtual_server', :type => 'define' do
     }
   end
 
+  context 'with a real_server without a port should default to VIP port' do
+    let(:params) {
+      {
+        :ip_address   => '10.1.1.1',
+        :port         => '8080',
+        :lb_algo      => 'lc',
+        :tcp_check    => { 'connect_timeout' => 5 },
+        :real_servers => [ { 'ip_address' => '10.1.1.2'} ]
+      }
+    }
+
+    it { 
+      should contain_concat__fragment('keepalived.conf_lvs_virtual_server__TITLE_').with( {
+        'content' => /real_server 10.1.1.2 8080 \{\s+TCP_CHECK \{\s+connect_port 8080\s+connect_timeout 5\s+\}\s+\}/
+      })
+    }
+  end
+
   context 'two real_servers' do
     let(:params) {
       {

--- a/templates/lvs_virtual_server.erb
+++ b/templates/lvs_virtual_server.erb
@@ -37,10 +37,11 @@ group <%= name %> {
 
   <%- if @real_servers -%>
     <%- @real_servers.each do |rs| -%>
-  real_server <%= rs['ip_address'] %> <%= rs['port'] %> {
+      <%- rs_port = rs['port'] || @port -%>
+  real_server <%= rs['ip_address'] %> <%= rs_port %> {
       <%- if @tcp_check -%>
     TCP_CHECK {
-      connect_port <%= rs['port'] %>
+      connect_port <%= rs_port %>
       connect_timeout <%= tcp_check['connect_timeout'] %>
     }
       <%- end -%>


### PR DESCRIPTION
This is the LVS support that we're using in production at Songkick. It only supports virtual IPs, not fwmark and it doesn't support any form of checking other than TCP_CHECK yet.

I've done a reasonable amount of parameter checking - in my experience with keepalived so far, if you give it a config file it doesn't understand it'll fail in non-obvious ways, so I thought it better to fail at puppet run time and avoid breaking a working keepalived.

One thing I'm not really sure about is the readability of the generated config fragments, I've put the virtual server definition inside a group <name> { } - there are various other ways of specifying this, but this one supports having multiple ip/ports bound to it using a separate virtual_server_group block (this isn't implemented yet). We could change the 'group' to 'virtual server group' if desired.
