### PR TITLE
fixed conflicting notify parameter. notify is a metaparameter

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -47,7 +47,7 @@
 # $lvs_interface::         Define lvs_sync_daemon_interface.
 #                          Default: undef.
 #
-# $notify::                Script to run during ANY state transit
+# $notify_script::         Script to run during ANY state transit
 #                          Default: undef.
 define keepalived::vrrp::instance (
   $interface,
@@ -62,7 +62,7 @@ define keepalived::vrrp::instance (
   $lvs_interface              = undef,
   $virtual_ipaddress_int      = undef,
   $virtual_ipaddress_excluded = undef,
-  $notify                     = undef,
+  $notify_script              = undef,
 ) {
   concat::fragment { "keepalived.conf_vrrp_instance_${name}":
     ensure  => $ensure,

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -96,11 +96,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
     }
   end
 
-  describe 'with parameter notify' do
+  describe 'with parameter notify_script' do
     let (:title) { '_NAME_' }
     let (:params) {
       {
-        :notify => '_VALUE_',
+        :notify_script => '_VALUE_',
         :virtual_ipaddress => [],
         :interface => '',
         :priority => '',

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -13,9 +13,9 @@ vrrp_instance <%= @name %> {
     auth_pass <%= @auth_pass %>
   }
   <%- end -%>
-  <%- if @notify -%>
+  <%- if @notify_script -%>
 
-  notify                    <%= @notify %>
+  notify                    <%= @notify_script %>
   <%- end -%>
   <%- if @track_script -%>
 


### PR DESCRIPTION
that was a dump idea to name that parameter "notify" in the manifest. Puppet throws an error, so I renamed that parameter to notify_script
