### PR TITLE
Feature: optional smtp_alert parameter for vrrp::instance

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -49,6 +49,10 @@
 #
 # $notify_script::         Script to run during ANY state transit
 #                          Default: undef.
+#
+# $smtp_alert::            Send status alerts via SMTP. Requires user provided
+#                          in SMTP settings in keepalived::global_defs class.
+#                          Default: false.
 define keepalived::vrrp::instance (
   $interface,
   $priority,
@@ -63,6 +67,7 @@ define keepalived::vrrp::instance (
   $virtual_ipaddress_int      = undef,
   $virtual_ipaddress_excluded = undef,
   $notify_script              = undef,
+  $smtp_alert                 = false,
 ) {
   concat::fragment { "keepalived.conf_vrrp_instance_${name}":
     ensure  => $ensure,

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -6,6 +6,9 @@ vrrp_instance <%= @name %> {
   <%- if @lvs_interface -%>
   lvs_sync_daemon_interface <%= @lvs_interface %>
   <%- end -%>
+  <%- if @smtp_alert -%>
+  smtp_alert
+  <%- end -%>
   <%- if @auth_type -%>
 
   authentication {
@@ -61,4 +64,3 @@ vrrp_instance <%= @name %> {
   }
   <%- end -%>
 }
-


### PR DESCRIPTION
Hey there, great work on the module! I made a small addition to the vrrp::instance class, the smtp_alert parameter. Defaults to false, so it won't cause any compatibility problems with active users.
