### PR TITLE
add garp_master_delay and advert_int support

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -60,9 +60,17 @@
 # $smtp_alert::            Send status alerts via SMTP. Requires user provided
 #                          in SMTP settings in keepalived::global_defs class.
 #                          Default: false.
-# $nopreempt::             allows the lower priority # machine to maintain the master role,
-#                          even when # a higher priority machine comes back online. #
-#                          NOTE: For this to work, the initial state of this # entry must be BACKUP
+#
+# $nopreempt::             Allows the lower priority machine to maintain the master role,
+#                          when a higher priority machine comes back online.
+#                          NOTE: For this to work, the initial state of this entry must be BACKUP
+#
+# $advert_int::            The interval between VRRP packets
+#                          Default: 1 second.
+#
+# $garp_master_delay::     The delay for gratuitous ARP after transition to MASTER
+#                          Default: 5 seconds.
+# 
 # $notify_script_master::  Define the notify master script.
 #                          Default: undef.
 #
@@ -92,6 +100,8 @@ define keepalived::vrrp::instance (
   $notify_script              = undef,
   $smtp_alert                 = false,
   $nopreempt                  = false,
+  $advert_int                 = 1,
+  $garp_master_delay          = 5,
   $notify_script_master       = undef,
   $notify_script_backup       = undef,
   $notify_script_fault        = undef,

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -405,6 +405,52 @@ describe 'keepalived::vrrp::instance', :type => :define do
     }
   end
 
+  describe 'with parameter advert_int' do
+    let (:title) { '_NAME_' }
+    let (:params) {
+      {
+        :advert_int => '_VALUE_',
+        :interface => '',
+        :priority => '',
+        :state => '',
+        :virtual_ipaddress => [],
+        :virtual_router_id => ''
+      }
+    }
+
+    it { should create_keepalived__vrrp__instance('_NAME_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /advert_int/,
+        'content' => /_VALUE_/
+      )
+    }
+  end
+
+ describe 'with parameter garp_master_delay' do
+    let (:title) { '_NAME_' }
+    let (:params) {
+      {
+        :garp_master_delay => '_VALUE_',
+        :interface => '',
+        :priority => '',
+        :state => '',
+        :virtual_ipaddress => [],
+        :virtual_router_id => ''
+      }
+    }
+
+    it { should create_keepalived__vrrp__instance('_NAME_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /garp_master_delay/,
+        'content' => /_VALUE_/
+      )
+    }
+  end
+
   describe 'with parameter virtual_ipaddress_int' do
     let (:title) { '_NAME_' }
     let (:params) {

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -3,13 +3,14 @@ vrrp_instance <%= @name %> {
   state                     <%= @state %>
   virtual_router_id         <%= @virtual_router_id %>
   priority                  <%= @priority %>
+  advert_int                <%= @advert_int %>
+  garp_master_delay         <%= @garp_master_delay %>
   <%- if @lvs_interface -%>
   lvs_sync_daemon_interface <%= @lvs_interface %>
   <%- end -%>
   <%- if @smtp_alert -%>
   smtp_alert
   <%- end -%>
-
   <%- if @nopreempt -%>
   nopreempt
   <%- end -%>


### PR DESCRIPTION
Adds support for setting the VRRP advert interval (advert_int) and ARP delay on master promotion (garp_master_delay).
