### PR TITLE
depend on puppetlabs/concat which replaces ripienaar's copy

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -7,5 +7,5 @@ description   'Keepalived vrrp and lvs failover module'
 project_page  'http://arioch.github.io/puppet-keepalived/'
 
 dependency    'puppetlabs/stdlib', '>= 4.0.0'
-dependency    'ripienaar/concat', '>= 0.2.0'
+dependency    'puppetlabs/concat', '>= 1.0.2'
 


### PR DESCRIPTION
The puppetlabs module is officially supported and replaces the ripienaar module. (It has for a couple years now).
