### PR TITLE
fixed virtual server ordering

### DIFF
--- a/manifests/lvs/virtual_server.pp
+++ b/manifests/lvs/virtual_server.pp
@@ -121,7 +121,7 @@ define keepalived::lvs::virtual_server (
   concat::fragment { "keepalived.conf_lvs_virtual_server_${name}-footer":
     target  => "${keepalived::config_dir}/keepalived.conf",
     content => "}\n",
-    order   => "251-${name}",
+    order   => "250-${name}",
   }
 
   if $collect_exported {


### PR DESCRIPTION
The ordering of virtual servers introduced by 29048da7d215a8799c7e780b40d034c3ab1bd381 means you get all the group definitions first followed by the closing braces, so the first group wraps the second group, etc, breaking the keepalived config:

```
group A {
  (group A config)
group B {
  (group B config)
}
}
```

This pull request fixes it to look like so:

```
group A {
  (group A config)
}
group B {
  (group B config)
}
```

The behaviour of the groups is badly broken by this, would it be possible to bump the version on puppet forge if you're happy with the pull request?
