### PR TITLE
Remove duplicate notify_script entry.

### DIFF
--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -55,10 +55,6 @@ vrrp_instance <%= @name %> {
     auth_pass <%= @auth_pass %>
   }
   <%- end -%>
-  <%- if @notify_script -%>
-
-  notify                    <%= @notify_script %>
-  <%- end -%>
   <%- if @track_script -%>
 
   track_script {


### PR DESCRIPTION
The notify_script block in vrrp_instance.erb is duplicated, this removes the duplication.
