### PR TITLE
Simplify array/single-value polymorphing

### DIFF
--- a/manifests/global_defs.pp
+++ b/manifests/global_defs.pp
@@ -28,14 +28,6 @@ class keepalived::global_defs(
   $router_id               = undef,
   $ensure                  = present,
 ){
-  if $notification_email {
-    if is_array($notification_email) {
-      $notification_email_array = $notification_email
-    }
-    else {
-      $notification_email_array = [$notification_email]
-    }
-  }
   concat::fragment { 'keepalived.conf_globaldefs':
     ensure  => $ensure,
     target  => "${keepalived::config_dir}/keepalived.conf",

--- a/manifests/vrrp/sync_group.pp
+++ b/manifests/vrrp/sync_group.pp
@@ -32,12 +32,6 @@ define keepalived::vrrp::sync_group (
   $smtp_alert           = undef,
   $nopreempt            = undef,
 ) {
-  if is_array($group) {
-    $group_array = $group
-  }
-  else {
-    $group_array = [$group]
-  }
   concat::fragment { "keepalived.conf_vrrp_sync_group_${name}":
     ensure  => $ensure,
     target  => "${keepalived::config_dir}/keepalived.conf",

--- a/templates/globaldefs.erb
+++ b/templates/globaldefs.erb
@@ -1,7 +1,7 @@
 global_defs {
-  <%- if @notification_email_array -%>
+  <%- if @notification_email -%>
   notification_email {
-    <%- @notification_email_array.each do |email| -%>
+    <%- Array(@notification_email).each do |email| -%>
     <%= email %>
     <%- end -%>
   }

--- a/templates/lvs_virtual_server.erb
+++ b/templates/lvs_virtual_server.erb
@@ -36,7 +36,7 @@ group <%= name %> {
   <%- end -%>
 
   <%- if @real_servers -%>
-    <%- @real_servers.each do |rs| -%>
+    <%- Array(@real_servers).each do |rs| -%>
       <%- rs_port = rs['port'] || @port -%>
   real_server <%= rs['ip_address'] %> <%= rs_port %> {
       <%- if @tcp_check -%>

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -58,15 +58,15 @@ vrrp_instance <%= @name %> {
   <%- if @track_script -%>
 
   track_script {
-    <% @track_script.each do |track| %><%= track %>
+    <% Array(@track_script).each do |track| %><%= track %>
     <%- end -%>
   }
   <%- end -%>
 
   <%- if @track_interface -%>
   track_interface {
-  <%- [@track_interface].flatten.each do |interface| -%>
-    <%= interface %> 
+  <%- Array(@track_interface).each do |interface| -%>
+    <%= interface %>
   <%- end -%>
   }
   <%- end -%>
@@ -77,7 +77,7 @@ vrrp_instance <%= @name %> {
   <%- else -%>
     <%- vips = @virtual_ipaddress -%>
   <%- end -%>
-  <%- vips.each do |ip| -%>
+  <%- Array(vips).each do |ip| -%>
     <%- if ip.class == Hash -%>
       <%- device = ip['dev'] || @virtual_ipaddress_int || @interface -%>
       <%- attrs = Hash[ ip.select { |k,v| ['label', 'brd', 'scope'].include? k } ] -%>

--- a/templates/vrrp_sync_group.erb
+++ b/templates/vrrp_sync_group.erb
@@ -1,6 +1,6 @@
 vrrp_sync_group <%= @name %> {
   group {
-  <%- @group_array.each do |vrrp_instance| -%>
+  <%- Array(@group).each do |vrrp_instance| -%>
     <%= vrrp_instance %>
   <%- end -%>
   }


### PR DESCRIPTION
I ran into an issue with the `track_script` and `virtual_ipaddress`
settings when passing a single value rather than an array. Wrapping with
`Array()` fixed the issue for me. I decided to go through and use the
same strategy in a couple other places to simplify and limber up the
code a bit.

Specs passing locally on 1.8.7-p375, 2.0.0-p353, and 2.1.1
