### PR TITLE
Add no_weight parameter on vrrp::script class

### DIFF
--- a/manifests/vrrp/script.pp
+++ b/manifests/vrrp/script.pp
@@ -20,14 +20,23 @@
 #             Default: undef
 #
 define keepalived::vrrp::script (
-  $interval = '2',
-  $script   = undef,
-  $weight   = '2',
-  $fall     = undef,
-  $rise     = undef,
+  $interval  = '2',
+  $script    = undef,
+  $weight    = undef,
+  $fall      = undef,
+  $rise      = undef,
+  $no_weight = false,
 ) {
   if ! $script {
     fail 'No script provided.'
+  }
+
+  if ! $weight {
+    $weight_real = 2
+  } else {
+    if $no_weight {
+      fail("Cannot enable no_weight and specify a weight!")
+    }
   }
 
   concat::fragment { "keepalived.conf_vrrp_script_${name}":

--- a/spec/defines/keepalived_vrrp_script_spec.rb
+++ b/spec/defines/keepalived_vrrp_script_spec.rb
@@ -66,6 +66,24 @@ describe 'keepalived::vrrp::script', :type => :define do
     }
   end
 
+  describe 'with parameter no_weight' do
+    let (:title) { '_TITLE_' }
+    let (:params) {
+      {
+        :no_weight => true,
+        :script => '_SCRIPT_'
+      }
+    }
+
+    it { should create_keepalived__vrrp__script('_TITLE_') }
+    it {
+      should_not \
+        contain_concat__fragment('keepalived.conf_vrrp_script__TITLE_').with(
+          'content' => /weight.*_VALUE_/
+      )
+    }
+  end
+
   describe 'with parameter fall' do
     let (:title) { '_TITLE_' }
     let (:params) {

--- a/templates/vrrp_script.erb
+++ b/templates/vrrp_script.erb
@@ -1,7 +1,9 @@
 vrrp_script <%= @name %> {
   script    "<%= @script %>"
   interval  <%= @interval %>
+  <%- unless @no_weight -%>
   weight    <%= @weight %>
+  <%- end -%>
   <%- if @fall -%>
   fall      <%= @fall %>
   <%- end -%>


### PR DESCRIPTION
Despite what the keepalived documentation says default weight for a
script is not 2, if none is specified.  What happens instead is that if
no weight is specified, then the associated VRRP instances go into FAULT
state and go offline.  If noprempt is enabled, this appears to be the
only way to get the VRRP instance to track the state of the script.

This adds a new parameter to the keepalived::vrrp::script define to
allow specifying that the weight parameter should not be put in the
config file at all.  This is implemented this way, because many configs
probably don't have a weight specified because the class will provide a
weight config of '2' if none is provided.  Most people are probably
using this default.
