### PR TITLE
support garp_master_refresh

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -71,6 +71,9 @@
 # $garp_master_delay::     The delay for gratuitous ARP after transition to MASTER
 #                          Default: 5 seconds.
 #
+# $garp_master_refresh::   Repeat gratuitous ARP after transition to MASTER this often.
+#                          Default: undef.
+#
 # $notify_script_master::  Define the notify master script.
 #                          Default: undef.
 #
@@ -102,6 +105,7 @@ define keepalived::vrrp::instance (
   $nopreempt                  = false,
   $advert_int                 = 1,
   $garp_master_delay          = 5,
+  $garp_master_refresh        = undef,
   $notify_script_master       = undef,
   $notify_script_backup       = undef,
   $notify_script_fault        = undef,

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -15,6 +15,9 @@ vrrp_instance <%= @name %> {
   nopreempt
   <%- end -%>
 
+  <%- if @garp_master_refresh -%>
+  garp_master_refresh         <%= @garp_master_refresh %>
+  <%- end -%>
 
   # notify scripts and alerts are optional
   #


### PR DESCRIPTION
Hello

I've added a parameter for the garp_master_refresh keepalived vrrp instance define

We need this in our environment as the network we VRRP over is subject to topology changes which without this setting cause the loss if the service IP address

Thanks,
