### PR TITLE
add stop notify script to instance

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -107,6 +107,9 @@
 # $notify_script_fault::   Define the notify fault script.
 #                          Default: undef.
 #
+# $notify_script_stop::    Define the notify stop script.
+#                          Default: undef.
+#
 # $notify_script::         Define the notify script.
 #                          Default: undef.
 
@@ -135,6 +138,7 @@ define keepalived::vrrp::instance (
   $notify_script_master       = undef,
   $notify_script_backup       = undef,
   $notify_script_fault        = undef,
+  $notify_script_stop         = undef,
   $notify_script              = undef,
 
 ) {

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -250,6 +250,28 @@ describe 'keepalived::vrrp::instance', :type => :define do
     }
   end
 
+  describe 'with parameter notify_script_stop' do
+    let (:title) { '_NAME_' }
+    let (:params) {
+      {
+        :notify_script_stop => '_VALUE_',
+        :virtual_ipaddress => [],
+        :interface => '',
+        :priority => '',
+        :state => '',
+        :virtual_router_id => ''
+      }
+    }
+
+    it { should create_keepalived__vrrp__instance('_NAME_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /notify_stop.*_VALUE_/
+      )
+    }
+  end
+
   describe 'with parameter notify_script' do
     let (:title) { '_NAME_' }
     let (:params) {

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -39,18 +39,23 @@ vrrp_instance <%= @name %> {
   # FAULT transition
   notify_fault <%= @notify_script_fault %>
   <%- end -%>
+  <%- if @notify_script_stop -%>
+  # STOP transition
+  notify_stop <%= @notify_script_stop %>
+  <%- end -%>
+
 
   <%- if @notify_script -%>
   # for ANY state transition.
   # "notify" script is called AFTER the
   # notify_* script(s) and is executed
-  # with 3 arguments provided by keepalived
+  # with 4 arguments provided by keepalived
   # (ie don't include parameters in the notify line).
   # arguments
   # $1 = "GROUP"|"INSTANCE"
   # $2 = name of group or instance
   # $3 = target state of transition
-  #     ("MASTER"|"BACKUP"|"FAULT")
+  #     ("MASTER"|"BACKUP"|"FAULT"|"STOP")
   notify <%= @notify_script %>
   <%- end -%>
 


### PR DESCRIPTION
Please consider adding notify_stop to keepalived's instance.
It's a valid directive since Release 1.1.13
see http://www.keepalived.org/changelog.html
