### PR TITLE
service: reload keepalived instead of restarting it

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class keepalived (
   $service_ensure     = $::keepalived::params::service_ensure,
   $service_hasrestart = $::keepalived::params::service_hasrestart,
   $service_hasstatus  = $::keepalived::params::service_hasstatus,
+  $service_restart    = $::keepalived::params::service_restart,
   $service_manage     = $::keepalived::params::service_manage,
   $service_name       = $::keepalived::params::service_name,
 ) inherits keepalived::params {
@@ -26,6 +27,7 @@ class keepalived (
   validate_re($service_ensure, ['^running$','^stopped$'])
   validate_bool($service_hasrestart)
   validate_bool($service_hasstatus)
+  validate_string($service_restart)
   validate_bool($service_manage)
   validate_string($service_name)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class keepalived::params {
       $pkg_list           = [ 'keepalived' ]
       $service_hasstatus  = true
       $service_hasrestart = true
+      $service_restart    = "/sbin/service keepalived reload"
       $service_name       = 'keepalived'
     }
 
@@ -33,6 +34,7 @@ class keepalived::params {
       $pkg_list           = [ 'keepalived' ]
       $service_hasrestart = false
       $service_hasstatus  = false
+      $service_restart    = "/usr/sbin/service keepalived reload"
       $service_name       = 'keepalived'
     }
 
@@ -47,6 +49,7 @@ class keepalived::params {
       $pkg_list           = [ 'keepalived' ]
       $service_hasrestart = false
       $service_hasstatus  = false
+      $service_restart    = "/etc/init.d/keepalived reload"
       $service_name       = 'keepalived'
     }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,6 +8,7 @@ class keepalived::service {
       enable     => $::keepalived::service_enable,
       hasrestart => $::keepalived::service_hasrestart,
       hasstatus  => $::keepalived::service_hasstatus,
+      restart    => $::keepalived::service_restart,
       require    => Class['::keepalived::config'],
     }
   }

--- a/spec/classes/keepalived_spec.rb
+++ b/spec/classes/keepalived_spec.rb
@@ -27,7 +27,8 @@ describe 'keepalived', :type => :class do
         'ensure'     => 'running',
         'enable'     => 'true',
         'hasrestart' => 'false',
-        'hasstatus'  => 'false'
+        'hasstatus'  => 'false',
+        'restart'    => '/usr/sbin/service keepalived reload'
       )
     }
   end
@@ -124,6 +125,15 @@ describe 'keepalived', :type => :class do
 
     it { should contain_service('keepalived').with(
         'hasstatus' => true
+      )
+    }
+  end
+
+  describe 'with parameter: service_restart' do
+    let (:params) { { :service_restart => '/something/else' } }
+
+    it { should contain_service('keepalived').with(
+        'restart' => '/something/else'
       )
     }
   end


### PR DESCRIPTION
Reloading generaly doesn't impact existing VIP and VS while restarting
has a major impact. By default, reload instead of restarting.

Closes: #52
