### PR TITLE
Ensure all concat fragment order parameters are consistent.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -30,13 +30,13 @@ class keepalived::config {
   concat::fragment { 'keepalived.conf_header':
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => "# Managed by Puppet\n",
-    order   => 001,
+    order   => '001',
   }
 
   concat::fragment { 'keepalived.conf_footer':
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => "\n",
-    order   => 999,
+    order   => '999',
   }
 }
 

--- a/manifests/global_defs.pp
+++ b/manifests/global_defs.pp
@@ -32,6 +32,6 @@ class keepalived::global_defs(
     ensure  => $ensure,
     target  => "${::keepalived::params::config_dir}/keepalived.conf",
     content => template('keepalived/globaldefs.erb'),
-    order   => 010,
+    order   => '010',
   }
 }

--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -170,7 +170,7 @@ define keepalived::vrrp::instance (
     ensure  => $ensure,
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => template('keepalived/vrrp_instance.erb'),
-    order   => 100,
+    order   => '100',
   }
 }
 

--- a/manifests/vrrp/script.pp
+++ b/manifests/vrrp/script.pp
@@ -42,7 +42,7 @@ define keepalived::vrrp::script (
   concat::fragment { "keepalived.conf_vrrp_script_${name}":
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => template('keepalived/vrrp_script.erb'),
-    order   => 02,
+    order   => '002',
   }
 }
 

--- a/manifests/vrrp/sync_group.pp
+++ b/manifests/vrrp/sync_group.pp
@@ -36,7 +36,7 @@ define keepalived::vrrp::sync_group (
     ensure  => $ensure,
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => template('keepalived/vrrp_sync_group.erb'),
-    order   => 050,
+    order   => '050',
   }
 }
 


### PR DESCRIPTION
While building a group of new servers with this, I noticed vrrp scripts weren't being used.  This was because the stanza for them was below the virtual instance, as was the header and global definitions.  Applying these changes locally fixed the ordering problems
- Ensure all order digits are 3 characters.
- Enclosing all order parameters in single quotes.
