### PR TITLE
Drop support for Puppet 3, Puppet 4 and Debian 7

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,38 +1,22 @@
 ---
-spec/spec_helper.rb
-  unmanaged: true
-spec/acceptance/nodesets/centos-65-x64.yml
-  delete: true
-spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
-  delete: true
-spec/acceptance/nodesets/archlinux-2-x64.yml
-  delete: true
-spec/acceptance/nodesets/ubuntu-server-10044-x64.yml
-  delete: true
-spec/acceptance/nodesets/centos-59-x64.yml
-  delete: true
-spec/acceptance/nodesets/debian-73-x64.yml
-  delete: true
-spec/acceptance/nodesets/default.yml
-  delete: true
-spec/acceptance/nodesets/ec2
-  delete: true
-spec/acceptance/nodesets/ec2/windows-2016-base-x64.yml
-  delete: true
-spec/acceptance/nodesets/ec2/amazonlinux-2016091.yml
-  delete: true
-spec/acceptance/nodesets/ec2/sles-12sp2-x64.yml
-  delete: true
-spec/acceptance/nodesets/ec2/ubuntu-1604-x64.yml
-  delete: true
-spec/acceptance/nodesets/ec2/image_templates.yaml
-  delete: true
-spec/acceptance/nodesets/ec2/rhel-73-x64.yml
-  delete: true
-spec/acceptance/nodesets/debian-70rc1-x64.yml
-  delete: true
 .travis.yml:
   docker_sets:
     - set: centos6-64
     - set: debian7-64
   secure: "GkH8b+4jKSQ9TwHnUca5HG5L1g+doS8k1Sp9/K7MBtzFdcWIZxVAc7xUNogq1BbKRm50aNcWbFK7NL5t3GkUH8fNuybZegLEdsrLhJAx57GplC9ip7qVVHsT6GjJ3MrdhbyCOvgHRprMpmENG5vqtXEfrnJ6LSf1MP3DkQPlfrY="
+spec/spec_helper.rb:
+  unmanaged: true
+spec/acceptance/nodesets/ec2/amazonlinux-2016091.yml:
+  delete: true
+spec/acceptance/nodesets/ec2/image_templates.yaml:
+  delete: true
+spec/acceptance/nodesets/ec2/rhel-73-x64.yml:
+  delete: true
+spec/acceptance/nodesets/ec2/sles-12sp2-x64.yml:
+  delete: true
+spec/acceptance/nodesets/ec2/ubuntu-1604-x64.yml:
+  delete: true
+spec/acceptance/nodesets/ec2/windows-2016-base-x64.yml:
+  delete: true
+spec/acceptance/nodesets/archlinux-2-x64.yml:
+  delete: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -2,7 +2,7 @@
 .travis.yml:
   docker_sets:
     - set: centos6-64
-    - set: debian7-64
+    - set: debian8-64
   secure: "GkH8b+4jKSQ9TwHnUca5HG5L1g+doS8k1Sp9/K7MBtzFdcWIZxVAc7xUNogq1BbKRm50aNcWbFK7NL5t3GkUH8fNuybZegLEdsrLhJAx57GplC9ip7qVVHsT6GjJ3MrdhbyCOvgHRprMpmENG5vqtXEfrnJ6LSf1MP3DkQPlfrY="
 spec/spec_helper.rb:
   unmanaged: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,15 +37,15 @@ matrix:
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=debian7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=debian8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,28 @@ matrix:
     env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=pc1 BEAKER_debug=true BEAKER_setfile=centos6-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos6-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=pc1 BEAKER_debug=true BEAKER_setfile=debian7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos6-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=centos6-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=debian7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
 branches:
   only:
   - master

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 
 ## Tested on...
 
-* Debian 7 (Wheezy)
-* Debian 6 (Squeeze)
+* Debian 8 (Jessie)
 * RHEL 6
 
 ## Example usage

--- a/metadata.json
+++ b/metadata.json
@@ -31,7 +31,7 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "7"
+        "8"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "puppet-keepalived",
-  "version": "1.3.0",
-  "author": "Voxpupuli",
+  "version": "2.0.0-rc0",
+  "author": "Vox Pupuli",
   "summary": "Keepalived module",
   "license": "Apache-2.0",
   "source": "https://github.com/voxpupuli/puppet-keepalived.git",
@@ -50,7 +50,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.8 < 5.0.0"
+      "version_requirement": ">= 5.5.8 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
At Vox Pupuli, we stopped supporting Puppet 4 after it went EOL.
https://voxpupuli.org/blog/2019/01/03/dropping-puppet4/

Debian 7 is also EOL and Puppet Inc don't publish Puppet 6 packages for it.