### PR TITLE
Revert "use Stdlib::Absolutepath datatype with vrrp script"

### DIFF
--- a/manifests/vrrp/script.pp
+++ b/manifests/vrrp/script.pp
@@ -29,7 +29,7 @@
 #             Default: undef
 #
 define keepalived::vrrp::script (
-  Stdlib::Absolutepath $script,
+  String[1] $script,
   $interval  = '2',
   $weight    = undef,
   $fall      = undef,

--- a/spec/defines/keepalived_vrrp_script_spec.rb
+++ b/spec/defines/keepalived_vrrp_script_spec.rb
@@ -22,7 +22,7 @@ describe 'keepalived::vrrp::script', type: :define do
         let(:params) do
           {
             interval: '_VALUE_',
-            script: '/bin/true'
+            script: '_SCRIPT_'
           }
         end
 
@@ -38,7 +38,7 @@ describe 'keepalived::vrrp::script', type: :define do
       describe 'with parameter script' do
         let(:params) do
           {
-            script: '/bin/true'
+            script: '_VALUE_'
           }
         end
 
@@ -46,7 +46,7 @@ describe 'keepalived::vrrp::script', type: :define do
         it {
           is_expected.to \
             contain_concat__fragment('keepalived.conf_vrrp_script__TITLE_').with(
-              'content' => %r{script.*/bin/true}
+              'content' => %r{script.*_VALUE_}
             )
         }
       end
@@ -55,7 +55,7 @@ describe 'keepalived::vrrp::script', type: :define do
         let(:params) do
           {
             weight: '_VALUE_',
-            script: '/bin/true'
+            script: '_SCRIPT_'
           }
         end
 
@@ -72,7 +72,7 @@ describe 'keepalived::vrrp::script', type: :define do
         let(:params) do
           {
             no_weight: true,
-            script: '/bin/true'
+            script: '_SCRIPT_'
           }
         end
 
@@ -89,7 +89,7 @@ describe 'keepalived::vrrp::script', type: :define do
         let(:params) do
           {
             fall: '_VALUE_',
-            script: '/bin/true'
+            script: '_SCRIPT_'
           }
         end
 
@@ -106,7 +106,7 @@ describe 'keepalived::vrrp::script', type: :define do
         let(:params) do
           {
             rise: '_VALUE_',
-            script: '/bin/true'
+            script: '_SCRIPT_'
           }
         end
 
@@ -123,7 +123,7 @@ describe 'keepalived::vrrp::script', type: :define do
         let(:params) do
           {
             timeout: '_VALUE_',
-            script: '/bin/true'
+            script: '_SCRIPT_'
           }
         end
 
@@ -140,7 +140,7 @@ describe 'keepalived::vrrp::script', type: :define do
         let(:params) do
           {
             user: '_VALUE_',
-            script: '/bin/true'
+            script: '_SCRIPT_'
           }
         end
 
@@ -158,7 +158,7 @@ describe 'keepalived::vrrp::script', type: :define do
           {
             user: '_USER_VALUE_',
             group: '_GROUP_VALUE_',
-            script: '/bin/true'
+            script: '_SCRIPT_'
           }
         end
 


### PR DESCRIPTION
Reverts voxpupuli/puppet-keepalived#177

The example in the readme is
```puppet
keepalived::vrrp::script { 'check_nginx':
  script => '/usr/bin/killall -0 nginx',
}
```