### PR TITLE
Change the fullcommand parameter to full_command for keepalived::vrrp::track_process

### DIFF
--- a/manifests/vrrp/track_process.pp
+++ b/manifests/vrrp/track_process.pp
@@ -17,7 +17,7 @@
 #             considering process failed (in fractions of second)
 #             Default: undef
 #
-# $fullcommand::  Match entire process cmdline
+# $full_command::  Match entire process cmdline
 #             Default: undef
 #
 define keepalived::vrrp::track_process (
@@ -25,17 +25,17 @@ define keepalived::vrrp::track_process (
   Optional[Integer[0]] $weight   = undef,
   Integer[0] $quorum             = 1,
   Optional[Integer[0]] $delay    = undef,
-  Boolean $fullcommand           = false
+  Boolean $full_command           = false
 ) {
   concat::fragment { "keepalived.conf_vrrp_track_process_${proc_name}":
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => epp('keepalived/vrrp_track_process.epp', {
-      'name'        => $name,
-      'proc_name'   => $proc_name,
-      'weight'      => $weight,
-      'quorum'      => $quorum,
-      'delay'       => $delay,
-      'fullcommand' => $fullcommand
+      'name'         => $name,
+      'proc_name'    => $proc_name,
+      'weight'       => $weight,
+      'quorum'       => $quorum,
+      'delay'        => $delay,
+      'full_command' => $full_command
     }),
     order   => '020',
   }

--- a/spec/defines/keepalived_vrrp_track_process_spec.rb
+++ b/spec/defines/keepalived_vrrp_track_process_spec.rb
@@ -85,10 +85,10 @@ describe 'keepalived::vrrp::track_process', type: :define do
         }
       end
 
-      describe 'with parameter fullcommand' do
+      describe 'with parameter full_command' do
         let(:params) do
           {
-            fullcommand: true,
+            full_command: true,
             proc_name:   '_PROC_NAME_'
           }
         end
@@ -97,7 +97,7 @@ describe 'keepalived::vrrp::track_process', type: :define do
         it do
           is_expected.to \
             contain_concat__fragment('keepalived.conf_vrrp_track_process__PROC_NAME_').with(
-              'content' => %r{fullcommand$}
+              'content' => %r{full_command$}
             )
         end
       end

--- a/templates/vrrp_track_process.epp
+++ b/templates/vrrp_track_process.epp
@@ -3,7 +3,7 @@
       Optional[Integer] $weight,
       Optional[Integer] $quorum,
       Optional[Integer] $delay,
-      Optional[Boolean] $fullcommand
+      Optional[Boolean] $full_command
     | -%>
 vrrp_track_process <%= $name %> {
   process    "<%= $proc_name %>"
@@ -16,8 +16,8 @@ vrrp_track_process <%= $name %> {
   <%- if $delay { -%>
   delay      <%= $delay %>
   <%- } -%>
-  <%- if $fullcommand { -%>
-  fullcommand
+  <%- if $full_command { -%>
+  full_command
   <%- } -%>
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
This change the parameter fullcommand to full_command for keepalived::vrrp::track_process
Extracted from the manual page of keepalived.conf (2.0.14) : http://www.keepalived.org/manpage.html
```
           vrrp_track_process <STRING> {
               # process to monitor
               process <QUOTED_STRING>

               # default weight (default is 1)
               weight <-254..254>

               # minimum number of processes for success
               quorum NUM
  
               # time to delay after process quorum lost before
               #   consider process failed (in fractions of second)
               delay SECS

               # Normally process string is matched against the process name,
               #   as shown on the Name: line in /proc/PID/status.
               #   This option matches the full command line
               full_command
           }


```
#### This Pull Request (PR) fixes the following issues
Fixes #179 
