### PR TITLE
Fix `Keepalived::Vrrp::Instance::VRule` syntax

### DIFF
--- a/types/vrrp/instance/vrule.pp
+++ b/types/vrrp/instance/vrule.pp
@@ -1,6 +1,6 @@
-type Keepalived::Vrrp::Instance::VRule = Struct[
+type Keepalived::Vrrp::Instance::VRule = Struct[{
   Optional[from]   => String,
   Optional[to]     => String,
   Optional[dev]    => String,
   Optional[lookup] => String
-]
+}]


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Set curly Braces in Type-Definition as stated in Puppet-Documentation.

#### This Pull Request (PR) fixes the following issues

Puppet-Parser 4.10.12 complains with "Syntax error at '=>'", whereas
Puppet-Parser 6.2 and 6.4 don't...
However Puppet-Documentation states, that curly Braces have to be there.
