### PR TITLE
Add support for the dynamic_interfaces option in the global_defs section

### DIFF
--- a/manifests/global_defs.pp
+++ b/manifests/global_defs.pp
@@ -26,6 +26,9 @@
 # $snmp_socket::                   Define snmp master agent socker
 #                                  Default: unix:/var/agentx/master
 #
+# $enable_dynamic_interfaces::     Set dynamic_interfaces option.
+#                                  Default: undef.
+#
 # $enable_snmp_keepalived::        Set enable_snmp_keepalived option.
 #                                  Default: undef.
 #
@@ -63,6 +66,7 @@ class keepalived::global_defs(
   $smtp_connect_timeout                           = undef,
   $router_id                                      = undef,
   $script_user                                    = undef,
+  $enable_dynamic_interfaces                      = undef,
   $enable_script_security                         = undef,
   $enable_snmp_keepalived                         = undef,
   $enable_snmp_checker                            = undef,

--- a/templates/globaldefs.erb
+++ b/templates/globaldefs.erb
@@ -21,8 +21,11 @@ global_defs {
   <%- if @script_user -%>
   script_user <%= @script_user %>
   <%- end -%>
-  <%- if @enable_script_security -%>
-  enable_script_security
+  <%- if @enable_dynamic_interfaces -%>
+  enable_dynamic_interfaces
+  <%- end -%>
+  <%- if @enable_snmp_keepalived -%>
+  enable_snmp_keepalived
   <%- end -%>
   <%- if @enable_snmp_keepalived -%>
   enable_snmp_keepalived


### PR DESCRIPTION
This PR adds support for the dynamic_interfaces option in the global_defs section who is actually missing.
