### PR TITLE
Drop EL6 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -44,14 +44,12 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     }


### PR DESCRIPTION
Now that CentOS 6 is EOL and is being removed from the mirror network we have no way to test this anymore.