### PR TITLE
Enable automatic unicast configuration with exported resources - pass tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,28 @@ class { '::keepalived':
 
 By default Keepalived will use multicast packets to determine failover conditions.
 However, in many cloud environments it is not possible to use multicast because of
-network restrictions. Keepalived can be configured to use unicast in such environments:
+network restrictions.
+Keepalived can be configured to use unicast in such environments:
+
+Enable automatic unicast configuration with exported resources by setting
+parameter 'collect\_unicast\_peers => true'
+
+**Automatic unicast configuration:
+
+```puppet
+  keepalived::vrrp::instance { 'VI_50':
+    interface         => 'eth1',
+    state             => 'BACKUP',
+    virtual_router_id => '50',
+    priority          => '100',
+    auth_type         => 'PASS',
+    auth_pass         => 'secret',
+    virtual_ipaddress => '10.0.0.1/29',
+    track_script      => 'check_nginx',
+    collect_unicast_peers => true,
+  }
+```
+**Manual unicast configuration or override auto default IP:
 
 ```puppet
   keepalived::vrrp::instance { 'VI_50':
@@ -334,10 +355,13 @@ network restrictions. Keepalived can be configured to use unicast in such enviro
     unicast_peers     => ['10.0.0.1', '10.0.0.2']
   }
 ```
-The 'unicast\_source\_ip' parameter is optional as Keepalived will bind to the specified interface by default.
-The 'unicast\_peers' parameter contains an array of ip addresses that correspond to the failover nodes.
+The 'unicast\_source\_ip' parameter is optional as Keepalived will bind to the
+specified interface by default. This value will be exported in place of the default
+when 'collect\_unicast\_peers => true'.
+The 'unicast\_peers' parameter contains an array of ip addresses that correspond
+to the failover nodes.
 
-
+ 
 ### Creating ip-based virtual server instances with two real servers
 
 This sets up a virtual server www.example.com that directs traffic to

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 #### Table of Contents
 
 1. [Description](#description)
-3. [Usage - Configuration options and additional functionality](#usage)
-4. [Limitations - OS compatibility, etc.](#limitations)
-5. [Development - Guide for contributing to the module](#development)
+2. [Usage - Configuration options and additional functionality](#usage)
+3. [Limitations - OS compatibility, etc.](#limitations)
+4. [Development - Guide for contributing to the module](#development)
 
 ## Description
 
@@ -25,7 +25,7 @@ The main goal of keepalived is to provide simple and robust facilities for loadb
 
 This configuration will fail-over when:
 
-a. Master node is unavailable
+1. Master node is unavailable
 
 ```puppet
 node /node01/ {
@@ -125,8 +125,8 @@ keepalived::vrrp_instance:
 
 This configuration will fail-over when:
 
-a. NGinX daemon is not running<br>
-b. Master node is unavailable
+1. NGinX daemon is not running
+1. Master node is unavailable
 
 ```puppet
 node /node01/ {
@@ -218,8 +218,8 @@ node /node01/ {
 
 This configuration will fail-over both the IPv4 address and the IPv6 address when:
 
-a. NGINX daemon is not running
-b. Master node is unavailable
+1. NGINX daemon is not running
+1. Master node is unavailable
 
 It is not possible to configure both IPv4 and IPv6 addresses as
 virtual\_ipaddresses in a single vrrp\_instance; the reason is that the VRRP
@@ -314,7 +314,7 @@ class { '::keepalived':
 
 ### Unicast instead of Multicast
 
-**caution: unicast support has only been added to Keepalived since version 1.2.8**
+**Caution: unicast support has only been added to Keepalived since version 1.2.8**
 
 By default Keepalived will use multicast packets to determine failover conditions.
 However, in many cloud environments it is not possible to use multicast because of
@@ -324,7 +324,7 @@ Keepalived can be configured to use unicast in such environments:
 Enable automatic unicast configuration with exported resources by setting
 parameter 'collect\_unicast\_peers => true'
 
-**Automatic unicast configuration:
+Automatic unicast configuration:
 
 ```puppet
   keepalived::vrrp::instance { 'VI_50':
@@ -339,7 +339,8 @@ parameter 'collect\_unicast\_peers => true'
     collect_unicast_peers => true,
   }
 ```
-**Manual unicast configuration or override auto default IP:
+
+Manual unicast configuration or override auto default IP:
 
 ```puppet
   keepalived::vrrp::instance { 'VI_50':
@@ -355,13 +356,13 @@ parameter 'collect\_unicast\_peers => true'
     unicast_peers     => ['10.0.0.1', '10.0.0.2']
   }
 ```
+
 The 'unicast\_source\_ip' parameter is optional as Keepalived will bind to the
 specified interface by default. This value will be exported in place of the default
 when 'collect\_unicast\_peers => true'.
 The 'unicast\_peers' parameter contains an array of ip addresses that correspond
 to the failover nodes.
 
- 
 ### Creating ip-based virtual server instances with two real servers
 
 This sets up a virtual server www.example.com that directs traffic to
@@ -498,4 +499,3 @@ The contributing guide is in [CONTRIBUTING.md](https://github.com/voxpupuli/pupp
 Details in `CHANGELOG.md`.
 
 Migrated from https://github.com/arioch/puppet-keepalived to Vox Pupuli.
-

--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -208,7 +208,7 @@ define keepalived::vrrp::instance (
   Boolean $native_ipv6                                                    = false,
 ) {
   $_name = regsubst($name, '[:\/\n]', '')
-  $unicast_peer_array = Array($unicast_peers, true)
+  $unicast_peer_array = [$unicast_peers].flatten
 
   concat::fragment { "keepalived.conf_vrrp_instance_${_name}":
     target  => "${keepalived::config_dir}/keepalived.conf",

--- a/manifests/vrrp/unicast_peer.pp
+++ b/manifests/vrrp/unicast_peer.pp
@@ -1,11 +1,22 @@
-# == Define: keepalived::vrrp::unicast_peer
+# @summary
+#   Define a unicast peer for a vrrp instance.
 #
-# === Parameters:
+# @api private
 #
-# $instance::   Name of vrrp instance this peer belongs to
+# @example Define a known, static unicast peer
+#   keepalived::vrrp::unicast_peer { '10.1.2.3':
+#     instance => 'my_vrrp_instance_name',
+#   }
 #
-# $ip_address:: IP address of unicast peer
-#               Default: $name
+# @example Export ourselves as a unicast peer for other peers to import
+#   @@keepalived::vrrp::unicast_peer { $facts['networking']['ip']:
+#     instance => 'my_vrrp_instance_name',
+#   }
+#
+# @param instance
+#   Name of vrrp instance this peer belongs to.
+# @param ip_address
+#   IP address of unicast peer. Defaults to $name.
 #
 define keepalived::vrrp::unicast_peer (
   String $instance,

--- a/manifests/vrrp/unicast_peer.pp
+++ b/manifests/vrrp/unicast_peer.pp
@@ -2,23 +2,22 @@
 #
 # === Parameters:
 #
-# $name::     IP address of unicast peer
-# $instance:: Name of vrrp instance this peer belongs to
+# $instance::   Name of vrrp instance this peer belongs to
+#
+# $ip_address:: IP address of unicast peer
+#               Default: $name
 #
 define keepalived::vrrp::unicast_peer (
-  $instance,
+  String $instance,
+  Stdlib::IP::Address $ip_address = $name,
 ) {
   assert_private()
 
   $_inst = regsubst($instance, '[:\/\n]', '')
 
-  validate_ip_address($name)
-
-  if ! has_ip_address($name) {
-    concat::fragment { "keepalived.conf_vrrp_instance_${_inst}_upeers_peer_${name}":
-      target  => "${keepalived::config_dir}/keepalived.conf",
-      content => "    ${title}\n",
-      order   => "100-${_inst}-010",
-    }
+  concat::fragment { "keepalived.conf_vrrp_instance_${_inst}_upeers_peer_${ip_address}":
+    target  => "${keepalived::config_dir}/keepalived.conf",
+    content => "    ${ip_address}\n",
+    order   => "100-${_inst}-020",
   }
 }

--- a/manifests/vrrp/unicast_peer.pp
+++ b/manifests/vrrp/unicast_peer.pp
@@ -1,0 +1,24 @@
+# == Define: keepalived::vrrp::unicast_peer
+#
+# === Parameters:
+#
+# $name::     IP address of unicast peer
+# $instance:: Name of vrrp instance this peer belongs to
+#
+define keepalived::vrrp::unicast_peer (
+  $instance,
+) {
+  assert_private()
+
+  $_inst = regsubst($instance, '[:\/\n]', '')
+
+  validate_ip_address($name)
+
+  if ! has_ip_address($name) {
+    concat::fragment { "keepalived.conf_vrrp_instance_${_inst}_upeers_peer_${name}":
+      target  => "${keepalived::config_dir}/keepalived.conf",
+      content => "    ${title}\n",
+      order   => "100-${_inst}-010",
+    }
+  }
+}

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -926,6 +926,18 @@ describe 'keepalived::vrrp::instance', type: :define do
         }
       end
 
+      describe 'with unicast_peers and collect_unicast_peers unset' do
+        let(:params) { mandatory_params }
+
+        it { is_expected.to create_keepalived__vrrp__instance('_NAME_') }
+        it {
+          is_expected.not_to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_header')
+          is_expected.not_to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_footer')
+        }
+      end
+
       describe 'with unicast_peers as array containing unicast peer ip addresses' do
         let(:params) do
           mandatory_params.merge(
@@ -962,11 +974,81 @@ describe 'keepalived::vrrp::instance', type: :define do
         }
       end
 
+      describe 'with unicast_peers set to a single ip address' do
+        let(:params) do
+          mandatory_params.merge(
+            unicast_peers: '10.0.3.0'
+          )
+        end
+
+        it { is_expected.to create_keepalived__vrrp__instance('_NAME_') }
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_header').with(
+              'content' => "  unicast_peer {\n"
+            )
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_peer_10.0.3.0').with(
+              'content' => "    10.0.3.0\n"
+            )
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_footer').with(
+              'content' => "  }\n\n"
+            )
+          is_expected.to \
+            contain_keepalived__vrrp__unicast_peer('10.0.3.0').with(
+              'instance' => '_NAME_'
+            )
+        }
+      end
+
+      describe 'with collect_unicast_peers set to true and unicast_peers set' do
+        let(:params) do
+          mandatory_params.merge(
+            collect_unicast_peers: true,
+            unicast_source_ip: '10.1.1.0',
+            unicast_peers: ['10.2.1.0', '10.2.2.0']
+          )
+        end
+
+        it { is_expected.to create_keepalived__vrrp__instance('_NAME_') }
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_header').with(
+              'content' => "  unicast_peer {\n"
+            )
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_peer_10.2.1.0').with(
+              'content' => "    10.2.1.0\n"
+            )
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_peer_10.2.2.0').with(
+              'content' => "    10.2.2.0\n"
+            )
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_footer').with(
+              'content' => "  }\n\n"
+            )
+          is_expected.to \
+            contain_keepalived__vrrp__unicast_peer('10.2.1.0').with(
+              'instance' => '_NAME_'
+            )
+          is_expected.to \
+            contain_keepalived__vrrp__unicast_peer('10.2.2.0').with(
+              'instance' => '_NAME_'
+            )
+          expect(exported_resources).to \
+            contain_keepalived__vrrp__unicast_peer('10.1.1.0').with(
+              'instance' => '_NAME_'
+            )
+        }
+      end
+
       describe 'with collect_unicast_peers set to true' do
         let(:params) do
           mandatory_params.merge(
             collect_unicast_peers: true,
-            unicast_source_ip: '10.0.3.0'
+            unicast_source_ip: '10.0.4.0'
           )
         end
 
@@ -981,7 +1063,7 @@ describe 'keepalived::vrrp::instance', type: :define do
               'content' => "  }\n\n"
             )
           expect(exported_resources).to \
-            contain_keepalived__vrrp__unicast_peer('10.0.3.0').with(
+            contain_keepalived__vrrp__unicast_peer('10.0.4.0').with(
               'instance' => '_NAME_'
             )
         }

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -897,7 +897,7 @@ describe 'keepalived::vrrp::instance', type: :define do
       describe 'with parameter unicast_source_ip' do
         let(:params) do
           mandatory_params.merge(
-            unicast_source_ip: '_VALUE_'
+            unicast_source_ip: '10.1.2.3'
           )
         end
 
@@ -905,7 +905,7 @@ describe 'keepalived::vrrp::instance', type: :define do
         it {
           is_expected.to \
             contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
-              'content' => %r{unicast_src_ip.*_VALUE_}
+              'content' => %r{unicast_src_ip.*10\.1\.2\.3}
             )
         }
       end
@@ -936,12 +936,53 @@ describe 'keepalived::vrrp::instance', type: :define do
         it { is_expected.to create_keepalived__vrrp__instance('_NAME_') }
         it {
           is_expected.to \
-            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
-              'content' => %r{10.0.1.0}
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_header').with(
+              'content' => "  unicast_peer {\n"
             )
           is_expected.to \
-            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
-              'content' => %r{10.0.2.0}
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_peer_10.0.1.0').with(
+              'content' => "    10.0.1.0\n"
+            )
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_peer_10.0.2.0').with(
+              'content' => "    10.0.2.0\n"
+            )
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_footer').with(
+              'content' => "  }\n\n"
+            )
+          is_expected.to \
+            contain_keepalived__vrrp__unicast_peer('10.0.1.0').with(
+              'instance' => '_NAME_'
+            )
+          is_expected.to \
+            contain_keepalived__vrrp__unicast_peer('10.0.2.0').with(
+              'instance' => '_NAME_'
+            )
+        }
+      end
+
+      describe 'with collect_unicast_peers set to true' do
+        let(:params) do
+          mandatory_params.merge(
+            collect_unicast_peers: true,
+            unicast_source_ip: '10.0.3.0'
+          )
+        end
+
+        it { is_expected.to create_keepalived__vrrp__instance('_NAME_') }
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_header').with(
+              'content' => "  unicast_peer {\n"
+            )
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME__upeers_footer').with(
+              'content' => "  }\n\n"
+            )
+          expect(exported_resources).to \
+            contain_keepalived__vrrp__unicast_peer('10.0.3.0').with(
+              'instance' => '_NAME_'
             )
         }
       end

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -195,16 +195,7 @@ vrrp_instance <%= @_name %> {
   <%- if @multicast_source_ip -%>
   mcast_src_ip <%= @multicast_source_ip %>
   <%- end -%>
+
   <%- if @unicast_source_ip -%>
   unicast_src_ip <%= @unicast_source_ip %>
   <%- end -%>
-
-  <%- if @unicast_peers -%>
-  unicast_peer {
-  <%- @unicast_peers.each do |peer| -%>
-    <%= peer %>
-  <%- end -%>
-  }
-  <%- end -%>
-
-}


### PR DESCRIPTION
#### Pull Request (PR) description

This is a continuation of #133, with the tests passing. Because the new code enforces use of `Stdlib::IP::Address`, it no longer supports setting `unicast_source_ip` to arbitrary strings, so I had to change `_VALUE_` to an ip address in the tests. Other changes were inward-facing, reflecting the shift from a single concat fragment to many.

#### This Pull Request (PR) fixes the following issues
Fixes #133 