### PR TITLE
make unicast-peer resource-name unique by adding the instance-name

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -230,12 +230,20 @@ define keepalived::vrrp::instance (
         $unicast_src = inline_template("<%= scope.lookupvar('::ipaddress_${interface}') -%>")
       }
 
-      @@keepalived::vrrp::unicast_peer { $unicast_src: instance => $name }
+      @@keepalived::vrrp::unicast_peer { "${name}_${unicast_src}":
+        instance   => $name,
+        ip_address => $unicast_src,
+      }
       Keepalived::Vrrp::Unicast_peer <<| instance == $name and title != $unicast_src |>>
     }
 
     if size($unicast_peer_array) > 0 {
-      keepalived::vrrp::unicast_peer { $unicast_peer_array: instance => $name }
+      $unicast_peer_array.each | $_peer | {
+        keepalived::vrrp::unicast_peer { "${name}_${_peer}":
+          instance   => $name,
+          ip_address => $_peer,
+        }
+      }
     }
 
     concat::fragment { "keepalived.conf_vrrp_instance_${_name}_upeers_footer":

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -964,12 +964,14 @@ describe 'keepalived::vrrp::instance', type: :define do
               'content' => "  }\n\n"
             )
           is_expected.to \
-            contain_keepalived__vrrp__unicast_peer('10.0.1.0').with(
-              'instance' => '_NAME_'
+            contain_keepalived__vrrp__unicast_peer('_NAME__10.0.1.0').with(
+              'instance' => '_NAME_',
+              'ip_address' => '10.0.1.0'
             )
           is_expected.to \
-            contain_keepalived__vrrp__unicast_peer('10.0.2.0').with(
-              'instance' => '_NAME_'
+            contain_keepalived__vrrp__unicast_peer('_NAME__10.0.2.0').with(
+              'instance' => '_NAME_',
+              'ip_address' => '10.0.2.0',
             )
         }
       end
@@ -996,8 +998,9 @@ describe 'keepalived::vrrp::instance', type: :define do
               'content' => "  }\n\n"
             )
           is_expected.to \
-            contain_keepalived__vrrp__unicast_peer('10.0.3.0').with(
-              'instance' => '_NAME_'
+            contain_keepalived__vrrp__unicast_peer('_NAME__10.0.3.0').with(
+              'instance' => '_NAME_',
+              'ip_address' => '10.0.3.0'
             )
         }
       end
@@ -1030,16 +1033,19 @@ describe 'keepalived::vrrp::instance', type: :define do
               'content' => "  }\n\n"
             )
           is_expected.to \
-            contain_keepalived__vrrp__unicast_peer('10.2.1.0').with(
-              'instance' => '_NAME_'
+            contain_keepalived__vrrp__unicast_peer('_NAME__10.2.1.0').with(
+              'instance' => '_NAME_',
+              'ip_address' => '10.2.1.0'
             )
           is_expected.to \
-            contain_keepalived__vrrp__unicast_peer('10.2.2.0').with(
-              'instance' => '_NAME_'
+            contain_keepalived__vrrp__unicast_peer('_NAME__10.2.2.0').with(
+              'instance' => '_NAME_',
+              'ip_address' => '10.2.2.0'
             )
           expect(exported_resources).to \
-            contain_keepalived__vrrp__unicast_peer('10.1.1.0').with(
-              'instance' => '_NAME_'
+            contain_keepalived__vrrp__unicast_peer('_NAME__10.1.1.0').with(
+              'instance' => '_NAME_',
+              'ip_address' => '10.1.1.0'
             )
         }
       end
@@ -1063,8 +1069,9 @@ describe 'keepalived::vrrp::instance', type: :define do
               'content' => "  }\n\n"
             )
           expect(exported_resources).to \
-            contain_keepalived__vrrp__unicast_peer('10.0.4.0').with(
-              'instance' => '_NAME_'
+            contain_keepalived__vrrp__unicast_peer('_NAME__10.0.4.0').with(
+              'instance' => '_NAME_',
+              'ip_address' => '10.0.4.0'
             )
         }
       end


### PR DESCRIPTION
Considering the following 3-node-setup:

| *Node* | *IP* |
| --- | --- |
| node1 | 10.0.0.1 |
| node2 | 10.0.0.2 |
| node3 | 10.0.0.3 |

There are two different VIPs bound to two separate VRRP-instances
* instance1, VIP primarily held by _node1_
* instance2, VIP primarily held by _node2_.

Both instances share the same unicast-peers - like in below config-snippet from _node1_ (10.0.0.1).

```yaml
keepalived::vrrp_instance:
  instance1:
    unicast_peers:
      - 10.0.0.2
      - 10.0.0.3
  instance2:
    unicast_peers:
      - 10.0.0.2
      - 10.0.0.3
```

That was a working config before - but by introducing the `keepalived::vrrp::unicast_peer` type in #227 this now fails as duplicate `keepalived::vrrp::unicast_peer` resources would get created with the same resource-names.

Therefor I would like to suggest binding the resource-name to the VRRP-instance.
Either by just looping over `$unicast_peer_array` like I've done in this PR.
Or in any other way.