### PR TITLE
add parameter param_match for VRRP tracking processes

### DIFF
--- a/manifests/vrrp/track_process.pp
+++ b/manifests/vrrp/track_process.pp
@@ -20,12 +20,17 @@
 # $full_command::  Match entire process cmdline
 #             Default: undef
 #
+# $param_match::  Set inital if command have no parameters or
+#             use partial if first n parameters match
+#             Default: undef
+#
 define keepalived::vrrp::track_process (
   String[1] $proc_name,
-  Optional[Integer[0]] $weight   = undef,
-  Integer[0] $quorum             = 1,
-  Optional[Integer[0]] $delay    = undef,
-  Boolean $full_command           = false
+  Optional[Integer[0]] $weight           = undef,
+  Integer[0] $quorum                     = 1,
+  Optional[Integer[0]] $delay            = undef,
+  Boolean $full_command                  = false,
+  Enum['initial','partial'] $param_match = undef
 ) {
   concat::fragment { "keepalived.conf_vrrp_track_process_${proc_name}":
     target  => "${keepalived::config_dir}/keepalived.conf",
@@ -35,7 +40,8 @@ define keepalived::vrrp::track_process (
         'weight'       => $weight,
         'quorum'       => $quorum,
         'delay'        => $delay,
-        'full_command' => $full_command
+        'full_command' => $full_command,
+        'param_match'  => $param_match
     }),
     order   => '020',
   }

--- a/spec/defines/keepalived_vrrp_track_process_spec.rb
+++ b/spec/defines/keepalived_vrrp_track_process_spec.rb
@@ -85,6 +85,23 @@ describe 'keepalived::vrrp::track_process', type: :define do
         }
       end
 
+      describe 'with parameter param_match' do
+        let(:params) do
+          {
+            param_match: initial,
+            proc_name: '_PROC_NAME_'
+          }
+        end
+
+        it { is_expected.to create_keepalived__vrrp__track_process('_PROC_NAME_') }
+        it do
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_track_process__PROC_NAME_').with(
+              'content' => %r{param_match.*initial}
+            )
+        end
+      end
+
       describe 'with parameter full_command' do
         let(:params) do
           {

--- a/templates/vrrp_track_process.epp
+++ b/templates/vrrp_track_process.epp
@@ -3,18 +3,22 @@
       Optional[Integer] $weight,
       Optional[Integer] $quorum,
       Optional[Integer] $delay,
+      Optional[String]  $param_match,
       Optional[Boolean] $full_command
     | -%>
 vrrp_track_process <%= $name %> {
-  process    "<%= $proc_name %>"
+  process     "<%= $proc_name %>"
   <%- if $weight { -%>
-  weight     <%= $weight %>
+  weight      <%= $weight %>
   <%- } -%>
   <%- if $quorum { -%>
-  quorum     <%= $quorum %>
+  quorum      <%= $quorum %>
   <%- } -%>
   <%- if $delay { -%>
-  delay      <%= $delay %>
+  delay       <%= $delay %>
+  <%- } -%>
+  <%- if $param_match { -%>
+  param_match <%= $param_match %>
   <%- } -%>
   <%- if $full_command { -%>
   full_command


### PR DESCRIPTION
#### Pull Request (PR) description
This pull requests adds the parameter param_match needed for VRRP to track processes.
Parameter stays undef it's not explizit set. Due to the manpage the parameter can only be initial or partial.

More information about the param in man pages: https://manpages.debian.org/unstable/keepalived/keepalived.conf.5.en.html

#### This Pull Request (PR) fixes the following issues
