### PR TITLE
Add enable_dbus option

### DIFF
--- a/manifests/global_defs.pp
+++ b/manifests/global_defs.pp
@@ -47,6 +47,9 @@
 # $enable_traps::                  Set enable_snmp_keepalived option.
 #                                  Default: undef.
 #
+# $enable_dbus::                   Set enable_dbus option
+#                                  Default: false.
+#
 # $vrrp_higher_prio_send_advert::  Set vrrp_higher_prio_send_advert option.
 #                                  Default: undef.
 #
@@ -74,6 +77,7 @@ class keepalived::global_defs (
   $enable_snmp_rfcv2                              = undef,
   $enable_snmp_rfcv3                              = undef,
   $enable_traps                                   = undef,
+  Boolean $enable_dbus                            = false,
   Optional[Boolean] $vrrp_higher_prio_send_advert = undef,
   Optional[Integer] $vrrp_garp_lower_prio_repeat  = undef,
   Optional[Integer] $vrrp_garp_master_refresh     = undef,

--- a/spec/classes/keepalived_global_defs_spec.rb
+++ b/spec/classes/keepalived_global_defs_spec.rb
@@ -236,6 +236,22 @@ describe 'keepalived::global_defs', type: :class do
             )
         }
       end
+
+      describe 'with parameter enable_dbus' do
+        let(:params) do
+          {
+            enable_dbus: true
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{enable_dbus$}
+            )
+        }
+      end
+
       describe 'with vrrp_higher_prio_send_advert' do
         let(:params) do
           {

--- a/templates/globaldefs.erb
+++ b/templates/globaldefs.erb
@@ -45,6 +45,9 @@ global_defs {
   <%- if @enable_traps -%>
   enable_traps
   <%- end -%>
+  <%- if @enable_dbus -%>
+  enable_dbus
+  <%- end -%>
   <%- if @vrrp_higher_prio_send_advert -%>
   vrrp_higher_prio_send_advert <%= @vrrp_higher_prio_send_advert %>
   <%- end -%>


### PR DESCRIPTION

#### Pull Request (PR) description
This PR allows the `enable_dbus` option from keepalived to be set via puppet/hiera.

