### PR TITLE
Allow virtual_ipaddress_excluded to be a string

### DIFF
--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -150,7 +150,7 @@ vrrp_instance <%= @_name %> {
   <%- else -%>
     <%- vips = @virtual_ipaddress_excluded -%>
   <%- end -%>
-  <%- vips.each do |ip| -%>
+  <%- Array(vips).each do |ip| -%>
     <%- if ip.class == Hash -%>
       <%- device = ip['dev'] || @virtual_ipaddress_int || @interface -%>
       <%- attrs = Hash[ ip.select { |k,v| ['label', 'brd', 'scope'].include? k } ] -%>


### PR DESCRIPTION
Documentation says a string is allowed, but it hadn't worked due to a code bug.
The same change was applied to virtual_ipaddress earlier. (see d1f58fe2)
