### PR TITLE
Add the possibility to manage the package outside the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,14 @@ class { '::keepalived':
 }
 ```
 
+### Opt out of having the package managed by the module
+
+```puppet
+class { '::keepalived':
+  manage_package => false,
+}
+```
+
 ### Unicast instead of Multicast
 
 **Caution: unicast support has only been added to Keepalived since version 1.2.8**

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,8 @@ class keepalived (
   String[1]               $service_name       = 'keepalived',
   Optional[String[1]]     $service_restart    = undef,
 
+  Boolean                 $manage_package     = true,
+
   Hash $vrrp_instance      = {},
   Hash $vrrp_script        = {},
   Hash $vrrp_track_process = {},

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,9 @@
 # == Class keepalived::install
 #
 class keepalived::install {
-  package { $keepalived::pkg_list:
-    ensure => $keepalived::pkg_ensure,
+  if $keepalived::manage_package {
+    package { $keepalived::pkg_list:
+      ensure => $keepalived::pkg_ensure,
+    }
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
I need the possibility to fix the version of keepalived, so, like service_manage, I introduce package_manage to install keepalived from another puppet module.

#### This Pull Request (PR) fixes the following issues
n/a
