### PR TITLE
Keepalived processes behaviour are tunable via globaldefs: prio, rt_prio, no_swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,18 @@ class { 'keepalived::global_defs':
   smtp_server             => 'localhost',
   smtp_connect_timeout    => '60',
   router_id               => 'your_router_instance_id',
+  bfd_rlimit_rttime       => 10000,
+  checker_rlimit_rttime   => 10000,
+  vrrp_rlimit_rttime      => 10000,
+  bfd_priority            => -20,
+  checker_priority        => -20,
+  vrrp_priority           => -20,
+  bfd_rt_priority         => 50,
+  checker_rt_priority     => 50,
+  vrrp_rt_priority        => 50,
+  bfd_no_swap             => true,
+  checker_no_swap         => true,
+  vrrp_no_swap            => true
 }
 ```
 

--- a/manifests/global_defs.pp
+++ b/manifests/global_defs.pp
@@ -43,6 +43,30 @@
 #
 # @param vrrp_startup_delay Set vrrp_startup_delay option.
 #
+# @param bfd_rlimit_rttime Set bfd_rlimit_rttime option.
+#
+# @param checker_rlimit_rttime Set checker_rlimit_rttime option.
+#
+# @param vrrp_rlimit_rttime Set vrrp_rlimit_rttime option.
+#
+# @param bfd_priority Set bfd_priority option.
+#
+# @param checker_priority Set checker_priority option.
+#
+# @param vrrp_priority Set vrrp_priority option.
+#
+# @param bfd_rt_priority Set bfd_rt_priority option.
+#
+# @param checker_rt_priority Set checker_rt_priority option.
+#
+# @param vrrp_rt_priority Set vrrp_rt_priority option.
+#
+# @param bfd_no_swap Set bfd_no_swap option.
+#
+# @param checker_no_swap Set checker_no_swap option.
+#
+# @param vrrp_no_swap Set vrrp_no_swap option.
+#
 class keepalived::global_defs (
   $notification_email                             = undef,
   $notification_email_from                        = undef,
@@ -64,6 +88,18 @@ class keepalived::global_defs (
   Optional[Integer] $vrrp_garp_master_refresh     = undef,
   Optional[Integer] $vrrp_garp_lower_prio_delay   = undef,
   Optional[Float] $vrrp_startup_delay             = undef,
+  Optional[Integer] $bfd_rlimit_rttime            = undef,
+  Optional[Integer] $checker_rlimit_rttime        = undef,
+  Optional[Integer] $vrrp_rlimit_rttime           = undef,
+  Optional[Integer[-20, 19]] $bfd_priority        = undef,
+  Optional[Integer[-20, 19]] $checker_priority    = undef,
+  Optional[Integer[-20, 19]] $vrrp_priority       = undef,
+  Optional[Integer[1, 99]] $bfd_rt_priority       = undef,
+  Optional[Integer[1, 99]] $checker_rt_priority   = undef,
+  Optional[Integer[1, 99]] $vrrp_rt_priority      = undef,
+  Boolean $bfd_no_swap                            = false,
+  Boolean $checker_no_swap                        = false,
+  Boolean $vrrp_no_swap                           = false,
   $snmp_socket                                    = 'unix:/var/agentx/master',
 ) {
   concat::fragment { 'keepalived.conf_globaldefs':

--- a/spec/classes/keepalived_global_defs_spec.rb
+++ b/spec/classes/keepalived_global_defs_spec.rb
@@ -341,6 +341,186 @@ describe 'keepalived::global_defs', type: :class do
             )
         }
       end
+
+      describe 'with parameter bfd_rlimit_rttime: 15000' do
+        let(:params) do
+          {
+            bfd_rlimit_rttime: 15_000
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{bfd_rlimit_rttime 15000}
+            )
+        }
+      end
+
+      describe 'with parameter checker_rlimit_rttime: 15000' do
+        let(:params) do
+          {
+            checker_rlimit_rttime: 15_000
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{checker_rlimit_rttime 15000}
+            )
+        }
+      end
+
+      describe 'with parameter vrrp_rlimit_rttime: 15000' do
+        let(:params) do
+          {
+            vrrp_rlimit_rttime: 15_000
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{vrrp_rlimit_rttime 15000}
+            )
+        }
+      end
+
+      describe 'with parameter bfd_priority: -15' do
+        let(:params) do
+          {
+            bfd_priority: -15
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{bfd_priority -15}
+            )
+        }
+      end
+
+      describe 'with parameter checker_priority: -15' do
+        let(:params) do
+          {
+            checker_priority: -15
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{checker_priority -15}
+            )
+        }
+      end
+
+      describe 'with parameter vrrp_priority: -15' do
+        let(:params) do
+          {
+            vrrp_priority: -15
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{vrrp_priority -15}
+            )
+        }
+      end
+
+      describe 'with parameter bfd_rt_priority: 99' do
+        let(:params) do
+          {
+            bfd_rt_priority: 99
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{bfd_rt_priority 99}
+            )
+        }
+      end
+
+      describe 'with parameter checker_rt_priority: 99' do
+        let(:params) do
+          {
+            checker_rt_priority: 99
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{checker_rt_priority 99}
+            )
+        }
+      end
+
+      describe 'with parameter vrrp_rt_priority: 99' do
+        let(:params) do
+          {
+            vrrp_rt_priority: 99
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{vrrp_rt_priority 99}
+            )
+        }
+      end
+
+      describe 'with parameter bfd_no_swap: true' do
+        let(:params) do
+          {
+            bfd_no_swap: true
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{bfd_no_swap}
+            )
+        }
+      end
+
+      describe 'with parameter checker_no_swap: true' do
+        let(:params) do
+          {
+            checker_no_swap: true
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{checker_no_swap}
+            )
+        }
+      end
+
+      describe 'with parameter vrrp_no_swap: true' do
+        let(:params) do
+          {
+            vrrp_no_swap: true
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{vrrp_no_swap}
+            )
+        }
+      end
     end
   end
 end

--- a/templates/globaldefs.erb
+++ b/templates/globaldefs.erb
@@ -63,6 +63,42 @@ global_defs {
   <%- if @vrrp_startup_delay -%>
   vrrp_startup_delay <%= @vrrp_startup_delay %>
   <%- end -%>
+  <%- if @bfd_rlimit_rttime -%>
+  bfd_rlimit_rttime <%= @bfd_rlimit_rttime %>
+  <%- end -%>
+  <%- if @checker_rlimit_rttime -%>
+  checker_rlimit_rttime <%= @checker_rlimit_rttime %>
+  <%- end -%>
+  <%- if @vrrp_rlimit_rttime -%>
+  vrrp_rlimit_rttime <%= @vrrp_rlimit_rttime %>
+  <%- end -%>
+  <%- if @bfd_priority -%>
+  bfd_priority <%= @bfd_priority %>
+  <%- end -%>
+  <%- if @checker_priority -%>
+  checker_priority <%= @checker_priority %>
+  <%- end -%>
+  <%- if @vrrp_priority -%>
+  vrrp_priority <%= @vrrp_priority %>
+  <%- end -%>
+  <%- if @bfd_rt_priority -%>
+  bfd_rt_priority <%= @bfd_rt_priority %>
+  <%- end -%>
+  <%- if @checker_rt_priority -%>
+  checker_rt_priority <%= @checker_rt_priority %>
+  <%- end -%>
+  <%- if @vrrp_rt_priority -%>
+  vrrp_rt_priority <%= @vrrp_rt_priority %>
+  <%- end -%>
+  <%- if @bfd_no_swap -%>
+  bfd_no_swap
+  <%- end -%>
+  <%- if @checker_no_swap -%>
+  checker_no_swap
+  <%- end -%>
+  <%- if @vrrp_no_swap -%>
+  vrrp_no_swap
+  <%- end -%>
   <%- if @snmp_socket -%>
   snmp_socket <%= @snmp_socket -%>
   <%- end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
I want to manage with this puppet module Keepalived process behaviour on my linux system:
* priority
* rt_prio
* no_swap

Ref: https://github.com/acassen/keepalived/blob/master/doc/man/man5/keepalived.conf.5.in

<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
None
