### PR TITLE
Allow to include external keepalived config fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,19 @@ class { '::keepalived':
 }
 ```
 
+### Opt out include unmanaged keepalived config files
+
+If you need to include a Keepalived config fragment managed by another tool,
+include_external_conf_files takes an array of config path.
+
+**Caution: config file must be readable by Keepalived daemon**
+
+```puppet
+class { 'keepalived':
+  include_external_conf_files => ['/etc/keepalived/unmanaged-config.cfg']
+}
+```
+
 ### Unicast instead of Multicast
 
 **Caution: unicast support has only been added to Keepalived since version 1.2.8**

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,6 +42,14 @@ class keepalived::config {
     order   => '001',
   }
 
+  concat::fragment { 'keepalived.conf_include_external_configs':
+    target  => "${keepalived::config_dir}/keepalived.conf",
+    content => epp('keepalived/include-external-configs.epp', {
+      'include_external_conf_files' => $keepalived::include_external_conf_files
+    }),
+    order   => '998',
+  }
+
   concat::fragment { 'keepalived.conf_footer':
     target  => "${keepalived::config_dir}/keepalived.conf",
     content => "\n",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,8 @@ class keepalived (
   Stdlib::Filemode     $config_dir_mode  = '0755',
   Stdlib::Filemode     $config_file_mode = '0644',
 
+  Array[Stdlib::Absolutepath] $include_external_conf_files = [],
+
   String[1] $config_group = 'root',
   String[1] $config_owner = 'root',
   String[1] $daemon_group = 'root',

--- a/templates/include-external-configs.epp
+++ b/templates/include-external-configs.epp
@@ -1,0 +1,5 @@
+<%- | Array[Stdlib::Absolutepath] $include_external_conf_files
+    | -%>
+<% $include_external_conf_files.each |$conf_file| { -%>
+include <%= $conf_file %>
+<% } -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Some fragments of my keepalived setup are managed by an external tool. I want to be able to include them as verbatim using include directive.
