### PR TITLE
support for vrrp_check_unicast_src option

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -321,6 +321,7 @@ The following parameters are available in the `keepalived::global_defs` class:
 * [`bfd_no_swap`](#bfd_no_swap)
 * [`checker_no_swap`](#checker_no_swap)
 * [`vrrp_no_swap`](#vrrp_no_swap)
+* [`vrrp_check_unicast_src`](#vrrp_check_unicast_src)
 * [`vrrp_version`](#vrrp_version)
 * [`max_auto_priority`](#max_auto_priority)
 
@@ -609,6 +610,14 @@ Default value: ``false``
 Data type: `Boolean`
 
 Set vrrp_no_swap option.
+
+Default value: ``false``
+
+##### <a name="vrrp_check_unicast_src"></a>`vrrp_check_unicast_src`
+
+Data type: `Boolean`
+
+Set vrrp_check_unicast_src option.
 
 Default value: ``false``
 

--- a/manifests/global_defs.pp
+++ b/manifests/global_defs.pp
@@ -73,6 +73,8 @@
 #
 # @param vrrp_no_swap Set vrrp_no_swap option.
 #
+# @param vrrp_check_unicast_src Set vrrp_check_unicast_src option.
+#
 # @param vrrp_version Set vrrp_version option.
 #
 # @param max_auto_priority Set max_auto_priority option.
@@ -113,6 +115,7 @@ class keepalived::global_defs (
   Boolean $bfd_no_swap                               = false,
   Boolean $checker_no_swap                           = false,
   Boolean $vrrp_no_swap                              = false,
+  Boolean $vrrp_check_unicast_src                    = false,
   Optional[Integer[2, 3]] $vrrp_version              = undef,
   Optional[Integer[-1, 99]] $max_auto_priority       = undef,
   $snmp_socket                                       = 'unix:/var/agentx/master',

--- a/spec/classes/keepalived_global_defs_spec.rb
+++ b/spec/classes/keepalived_global_defs_spec.rb
@@ -569,6 +569,21 @@ describe 'keepalived::global_defs', type: :class do
         }
       end
 
+      describe 'with parameter vrrp_check_unicast_src: true' do
+        let(:params) do
+          {
+            vrrp_check_unicast_src: true
+          }
+        end
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{vrrp_check_unicast_src}
+            )
+        }
+      end
+
       describe 'with parameter vrrp_version: 3' do
         let(:params) do
           {

--- a/templates/globaldefs.erb
+++ b/templates/globaldefs.erb
@@ -108,6 +108,9 @@ global_defs {
   <%- if @vrrp_no_swap -%>
   vrrp_no_swap
   <%- end -%>
+  <%- if @vrrp_check_unicast_src -%>
+  vrrp_check_unicast_src
+  <%- end -%>
   <%- if @vrrp_version -%>
   vrrp_version <%= @vrrp_version -%>
   <%- end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

This pull request allows the vrrp_check_unicast_src option to be set in keepalived.conf.

#### This Pull Request (PR) fixes the following issues

Was unable to set vrrp_check_unicast_src option using the existing module code.