### PR TITLE
Extend and modify virtual rule options

### DIFF
--- a/types/vrrp/instance/vrule.pp
+++ b/types/vrrp/instance/vrule.pp
@@ -1,8 +1,10 @@
 # @summary keepalived::vrrp::instance::vrule
 #
 type Keepalived::Vrrp::Instance::VRule = Struct[{
-    Optional[from]   => String,
-    Optional[to]     => String,
-    Optional[dev]    => String,
-    Optional[lookup] => String
+    Optional[from]     => String,
+    Optional[to]       => String,
+    Optional[iif]      => String,
+    Optional[oif]      => String,
+    Optional[priority] => String,
+    Optional[table]    => String
 }]


### PR DESCRIPTION
**Pull Request (PR) description**

This pull request extends & modifies the virtual_rules options.
The idea is to try to stick close to the iproute options (see ip-rule manpage).
Currently for some options aliases are used, which is confusing.

Summary of the changes:

- Adds the oif and priority options
- Replaces the (undocumented) dev option with its iif alias
- Replaces the lookup option with its table alias

The tests are also extended to incorporate all possible options.

**This Pull Request (PR) fixes the following issues**

None
