### PR TITLE
Add support for promote_secondaries option

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1050,6 +1050,7 @@ The following parameters are available in the `keepalived::vrrp::instance` defin
 * [`state`](#state)
 * [`virtual_ipaddress_int`](#virtual_ipaddress_int)
 * [`virtual_ipaddress`](#virtual_ipaddress)
+* [`promote_secondaries`](#promote_secondaries)
 * [`virtual_routes`](#virtual_routes)
 * [`virtual_rules`](#virtual_rules)
 * [`virtual_ipaddress_excluded`](#virtual_ipaddress_excluded)
@@ -1116,6 +1117,14 @@ Data type: `Any`
 Set floating IP address.
 
 Default value: ``undef``
+
+##### <a name="promote_secondaries"></a>`promote_secondaries`
+
+Data type: `Boolean`
+
+Stop other addresses in the same CIDR being removed when one of them is removed
+
+Default value: ``false``
 
 ##### <a name="virtual_routes"></a>`virtual_routes`
 

--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -25,6 +25,13 @@
 #      e.g. `{ 'ip' => '10.0.0.1', 'label' => 'webvip' }`
 #      Supported properties: dev, brd, label, scope.
 #
+# @param promote_secondaries
+#   Set the promote_secondaries flag on the interface to stop other
+#   addresses in the same CIDR being removed when 1 of them is removed
+#   For example if 10.1.1.2/24 and 10.1.1.3/24 are both configured on an
+#   interface, and one is removed, unless promote_secondaries is set on
+#   the interface the other address will also be removed.
+#
 # @param virtual_routes
 #   Set floating routes.
 #
@@ -180,7 +187,7 @@
 # @param higher_prio_send_advert
 #
 # @param collect_unicast_peers
-# 
+#
 define keepalived::vrrp::instance (
   $interface,
   Integer[1,254] $priority,
@@ -195,6 +202,7 @@ define keepalived::vrrp::instance (
   $lvs_interface                                                          = undef,
   $virtual_ipaddress_int                                                  = undef,
   $virtual_ipaddress_excluded                                             = undef,
+  Boolean $promote_secondaries                                            = false,
   $virtual_routes                                                         = undef,
   Optional[Array[Keepalived::Vrrp::Instance::VRule]] $virtual_rules       = undef,
   $smtp_alert                                                             = false,

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -805,6 +805,23 @@ describe 'keepalived::vrrp::instance', type: :define do
         }
       end
 
+      describe 'with promote_secondaries' do
+        let(:params) do
+          mandatory_params.merge(
+            promote_secondaries: true
+          )
+        end
+
+        it { is_expected.to create_keepalived__vrrp__instance('_NAME_') }
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+              'content' => %r{promote_secondaries}
+            )
+        }
+      end
+
       describe 'with virtual_routes as hash' do
         let(:params) do
           mandatory_params.merge(

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -172,6 +172,10 @@ vrrp_instance <%= @_name %> {
   <%- end -%>
   }
   <%- end -%>
+  <%- if @promote_secondaries -%>
+
+  promote_secondaries
+  <%- end -%>
   <%- if @virtual_routes -%>
 
   virtual_routes {


### PR DESCRIPTION
#### Pull Request (PR) description

promote_secondaries is a boolean flag at the vrrp instance level that allows you to remove an address without removing the other addresses in the same CIDR. See https://keepalived.org/manpage.html
