### PR TITLE
Add missing vrule fields

### DIFF
--- a/types/vrrp/instance/vrule.pp
+++ b/types/vrrp/instance/vrule.pp
@@ -1,8 +1,25 @@
 # @summary keepalived::vrrp::instance::vrule
-#
+# @description Translates directly to rules to be added as per `ip-rule(8)`
 type Keepalived::Vrrp::Instance::VRule = Struct[{
-    Optional[from]   => String,
-    Optional[to]     => String,
-    Optional[dev]    => String,
-    Optional[lookup] => String
+    Optional[from]                  => String,
+    Optional[to]                    => String,
+    Optional[iif]                   => String,
+    Optional[oof]                   => String,
+    Optional[lookup]                => String,
+    Optional[table]                 => String,
+    Optional[tos]                   => String,
+    Optional[dsfield]               => String,
+    Optional[fwmark]                => String,
+    Optional[uidrange]              => String,
+    Optional[ipproto]               => String,
+    Optional[sport]                 => String,
+    Optional[dport]                 => String,
+    Optional[priority]              => String,
+    Optional[preference]            => String,
+    Optional[order]                 => String,
+    Optional[protocol]              => String,
+    Optional[suppress_prefixlength] => String,
+    Optional[suppress_ifgroup]      => String,
+    Optional[realms]                => String,
+    Optional[nat]                   => String,
 }]


### PR DESCRIPTION
#### Pull Request (PR) description

I've added all the missing possible fields for `keepalived::vrrp::instance::vrule` as per `ip-rule(8)`, since they can all be used.

Also, `dev` was wrong.

#### This Pull Request (PR) fixes the following issues

n/a