### PR TITLE
add parameter use_vmac_addr to VRRP instance

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1090,6 +1090,7 @@ The following parameters are available in the `keepalived::vrrp::instance` defin
 * [`dont_track_primary`](#dont_track_primary)
 * [`use_vmac`](#use_vmac)
 * [`vmac_xmit_base`](#vmac_xmit_base)
+* [`use_vmac_addr`](#use_vmac_addr)
 * [`native_ipv6`](#native_ipv6)
 * [`garp_lower_prio_repeat`](#garp_lower_prio_repeat)
 * [`higher_prio_send_advert`](#higher_prio_send_advert)
@@ -1394,7 +1395,7 @@ Default value: ``false``
 
 Data type: `Any`
 
-Use virtual MAC address for virtual IP addresses.
+Use virtual MAC address for VRRP packages.
 
 Default value: ``false``
 
@@ -1407,6 +1408,14 @@ VRRP messaged on the underlying interface whilst ARP
 will happen from the the VMAC interface.
 
 Default value: ``true``
+
+##### <a name="use_vmac_addr"></a>`use_vmac_addr`
+
+Data type: `Boolean`
+
+Use virtual MAC address for virtual IP addresses.
+
+Default value: ``false``
 
 ##### <a name="native_ipv6"></a>`native_ipv6`
 

--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -176,12 +176,15 @@
 #   Default: false.
 #
 # @param use_vmac
-#   Use virtual MAC address for virtual IP addresses.
+#   Use virtual MAC address for VRRP packages.
 #
 # @param vmac_xmit_base
 #   When using virtual MAC addresses transmit and receive
 #   VRRP messaged on the underlying interface whilst ARP
 #   will happen from the the VMAC interface.
+#
+# @param use_vmac_addr
+#   Use virtual MAC address for virtual IP addresses.
 #
 # @param native_ipv6 Force instance to use IPv6 (when mixed IPv4 and IPv6 config)
 #
@@ -230,6 +233,7 @@ define keepalived::vrrp::instance (
   $dont_track_primary                                                     = false,
   $use_vmac                                                               = false,
   $vmac_xmit_base                                                         = true,
+  Boolean $use_vmac_addr                                                  = false,
   Boolean $native_ipv6                                                    = false,
 ) {
   $_name = regsubst($name, '[:\/\n]', '')

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -1353,6 +1353,23 @@ describe 'keepalived::vrrp::instance', type: :define do
         }
       end
 
+      describe 'with use_vmac_addr' do
+        let(:params) do
+          mandatory_params.merge(
+            use_vmac_addr: true
+          )
+        end
+
+        it { is_expected.to create_keepalived__vrrp__instance('_NAME_') }
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+              'content' => %r{use_vmac_addr}
+            )
+        }
+      end
+
       describe 'with native_ipv6' do
         let(:params) do
           mandatory_params.merge(

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -40,6 +40,9 @@ vrrp_instance <%= @_name %> {
   vmac_xmit_base
   <%- end -%>
   <%- end -%>
+  <%- if @use_vmac_addr -%>
+  use_vmac_addr
+  <%- end -%>
   <%- if @native_ipv6 -%>
 
   native_ipv6


### PR DESCRIPTION
#### Pull Request (PR) description

The `use_vmac_addr` parameter tells keepalived to use virtual MAC addresses for virtual IPs.

The parameter `use_vmac` only affects VRRP packages.