### PR TITLE
Correctly handle track_file for keepalived < 2.1.0

### DIFF
--- a/manifests/vrrp/track_file.pp
+++ b/manifests/vrrp/track_file.pp
@@ -19,15 +19,31 @@ define keepalived::vrrp::track_file (
   Optional[String[1]] $init_file  = undef,
   Boolean $overwrite              = false,
 ) {
-  concat::fragment { "keepalived.conf_vrrp_track_file_${file_name}":
-    target  => "${keepalived::config_dir}/keepalived.conf",
-    content => epp('keepalived/vrrp_track_file.epp', {
-        'name'      => $name,
-        'file_name' => $file_name,
-        'weight'    => $weight,
-        'init_file' => $init_file,
-        'overwrite' => $overwrite,
-    }),
-    order   => '015',
+
+  if SemVer.new($facts["keepalived_version"]) >= SemVer.new("2.1.0") {
+    concat::fragment { "keepalived.conf_vrrp_track_file_${file_name}":
+      target  => "${keepalived::config_dir}/keepalived.conf",
+      content => epp('keepalived/track_file.epp', {
+          'name'      => $name,
+          'file_name' => $file_name,
+          'weight'    => $weight,
+          'init_file' => $init_file,
+          'overwrite' => $overwrite,
+      }),
+      order   => '015',
+    }
+  
+  } else {
+    concat::fragment { "keepalived.conf_vrrp_track_file_${file_name}":
+      target  => "${keepalived::config_dir}/keepalived.conf",
+      content => epp('keepalived/vrrp_track_file.epp', {
+          'name'      => $name,
+          'file_name' => $file_name,
+          'weight'    => $weight,
+          'init_file' => $init_file,
+          'overwrite' => $overwrite,
+      }),
+      order   => '015',
+    }
   }
 }

--- a/templates/track_file.epp
+++ b/templates/track_file.epp
@@ -4,7 +4,7 @@
       Optional[String]  $init_file,
       Optional[Boolean] $overwrite
     | -%>
-vrrp_track_file <%= $name %> {
+track_file <%= $name %> {
   file     "<%= $file_name %>"
   <%- if $weight { -%>
   weight      <%= $weight %>

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -114,7 +114,7 @@ vrrp_instance <%= @_name %> {
 
   track_file {
   <%- Array(@track_file).each do |track| -%>
-    <%= track %> weight 1
+    <%= track %>
   <%- end -%>
   }
   <%- end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR solves two issues related to keepalive configuration:

- For versions of keepalived < 2.1.0, the "track_file" config stanza should be called "vrrp_track_file". The manpage for keepalived.conf confirms the deprecation, I found the exact version by digging through the source code for keepalived.
- The previous implementation of this module allowed a particular file to have a given weight, but when the track_file was referenced inside the vrrp_instance, the weight was reassigned to "1". According to the keepalived.conf manpage, the weight defined inside vrrp_instance defaults to weight configured in track_file. It should be safe to remove.

#### This Pull Request (PR) fixes the following issues
Fixes #278

