### PR TITLE
Add support for the init_fail parameter to keepalived::vrrp::script

### DIFF
--- a/manifests/vrrp/script.pp
+++ b/manifests/vrrp/script.pp
@@ -18,6 +18,8 @@
 #
 # @param no_weight
 #
+# @param init_fail assume script initially is in failed state if true.
+#
 define keepalived::vrrp::script (
   String[1] $script,
   $interval  = '2',
@@ -28,6 +30,7 @@ define keepalived::vrrp::script (
   $user      = undef,
   $group     = undef,
   $no_weight = false,
+  $init_fail = false,
 ) {
   $_name = regsubst($name, '[:\/\n]', '')
 

--- a/spec/defines/keepalived_vrrp_script_spec.rb
+++ b/spec/defines/keepalived_vrrp_script_spec.rb
@@ -181,6 +181,24 @@ describe 'keepalived::vrrp::script', type: :define do
             )
         }
       end
+
+      describe 'with parameter init_fail' do
+        let(:params) do
+          {
+            init_fail: true,
+            script: '_SCRIPT_'
+          }
+        end
+
+        it { is_expected.to create_keepalived__vrrp__script('_TITLE_') }
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_script__TITLE_').with(
+              'content' => %r{init_fail}
+            )
+        }
+      end
     end
   end
 end

--- a/templates/vrrp_script.erb
+++ b/templates/vrrp_script.erb
@@ -16,5 +16,8 @@ vrrp_script <%= @_name %> {
   <%- if @user -%>
   user      <%= @user %><% if @group %> <%= @group %><% end %>
   <%- end -%>
+  <%- if @init_fail -%>
+  init_fail
+  <%- end -%>
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Add support for the init_fail parameter to keepalived::vrrp::script

#### This Pull Request (PR) fixes the following issues
Fixes #257 