### PR TITLE
Replace all occurrences of illegal chars in the name var

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1477,6 +1477,7 @@ The following parameters are available in the `keepalived::vrrp::script` defined
 * [`user`](#-keepalived--vrrp--script--user)
 * [`group`](#-keepalived--vrrp--script--group)
 * [`no_weight`](#-keepalived--vrrp--script--no_weight)
+* [`init_fail`](#-keepalived--vrrp--script--init_fail)
 
 ##### <a name="-keepalived--vrrp--script--interval"></a>`interval`
 
@@ -1545,6 +1546,14 @@ Default value: `undef`
 Data type: `Any`
 
 
+
+Default value: `false`
+
+##### <a name="-keepalived--vrrp--script--init_fail"></a>`init_fail`
+
+Data type: `Any`
+
+assume script initially is in failed state if true.
 
 Default value: `false`
 

--- a/manifests/lvs/real_server.pp
+++ b/manifests/lvs/real_server.pp
@@ -30,7 +30,7 @@ define keepalived::lvs::real_server (
   Stdlib::Port $port,
   Keepalived::Options $options = {},
 ) {
-  $_name = regsubst($name, '[:\/\n]', '')
+  $_name = regsubst($name, '[:\/\n]', '', 'G')
 
   concat::fragment { "keepalived.conf_lvs_real_server_${_name}":
     target  => "${keepalived::config_dir}/keepalived.conf",

--- a/manifests/lvs/virtual_server.pp
+++ b/manifests/lvs/virtual_server.pp
@@ -99,7 +99,7 @@ define keepalived::lvs::virtual_server (
   Hash $real_server_options = {},
   Optional[Stdlib::Fqdn] $virtualhost = undef,
 ) {
-  $_name = regsubst($name, '[:\/\n]', '')
+  $_name = regsubst($name, '[:\/\n]', '', 'G')
 
   unless $fwmark {
     assert_type(Stdlib::Port, $port)

--- a/manifests/vrrp/script.pp
+++ b/manifests/vrrp/script.pp
@@ -32,7 +32,7 @@ define keepalived::vrrp::script (
   $no_weight = false,
   $init_fail = false,
 ) {
-  $_name = regsubst($name, '[:\/\n]', '')
+  $_name = regsubst($name, '[:\/\n]', '', 'G')
 
   if ! $weight {
     $weight_real = 2

--- a/manifests/vrrp/sync_group.pp
+++ b/manifests/vrrp/sync_group.pp
@@ -45,7 +45,7 @@ define keepalived::vrrp::sync_group (
   Boolean $global_tracking                                          = false,
   Optional[Variant[String, Array[String]]] $track_interface         = undef,
 ) {
-  $_name = regsubst($name, '[:\/\n]', '')
+  $_name = regsubst($name, '[:\/\n]', '', 'G')
 
   concat::fragment { "keepalived.conf_vrrp_sync_group_${_name}":
     target  => "${keepalived::config_dir}/keepalived.conf",


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
When sanitizing the `$name` variable, the `regsubst` function should replace _all_ their occurrences instead of just the first one.
-->