### PR TITLE
Add `terminate_delay` and `fork_delay` parameters to `keepalived::vrrp::track_process`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -36,7 +36,7 @@ Work in progress, supports:
 ### Data types
 
 * [`Keepalived::Options`](#Keepalived--Options): keepalived::options
-* [`Keepalived::Vrrp::Instance::VRule`](#Keepalived--Vrrp--Instance--VRule): keepalived::vrrp::instance::vrule
+* [`Keepalived::Vrrp::Instance::VRule`](#Keepalived--Vrrp--Instance--VRule): Translates directly to rules to be added as per `ip-rule(8)`
 
 ## Classes
 
@@ -1842,7 +1842,7 @@ Alias of `Hash[String[1], Any]`
 
 ### <a name="Keepalived--Vrrp--Instance--VRule"></a>`Keepalived::Vrrp::Instance::VRule`
 
-keepalived::vrrp::instance::vrule
+Translates directly to rules to be added as per `ip-rule(8)`
 
 Alias of
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1719,6 +1719,8 @@ The following parameters are available in the `keepalived::vrrp::track_process` 
 * [`weight`](#-keepalived--vrrp--track_process--weight)
 * [`quorum`](#-keepalived--vrrp--track_process--quorum)
 * [`delay`](#-keepalived--vrrp--track_process--delay)
+* [`fork_delay`](#-keepalived--vrrp--track_process--fork_delay)
+* [`terminate_delay`](#-keepalived--vrrp--track_process--terminate_delay)
 * [`full_command`](#-keepalived--vrrp--track_process--full_command)
 * [`param_match`](#-keepalived--vrrp--track_process--param_match)
 
@@ -1748,7 +1750,23 @@ Default value: `1`
 
 Data type: `Optional[Integer[0]]`
 
-Time to delay after process quorum lost before considering process failed (in fractions of second)
+this sets fork_delay and terminate_delay (for keepalived => 2.0.16), before terminate_delay
+
+Default value: `undef`
+
+##### <a name="-keepalived--vrrp--track_process--fork_delay"></a>`fork_delay`
+
+Data type: `Optional[Integer[0]]`
+
+time to delay after process quorum gained after fork before consider process up
+
+Default value: `undef`
+
+##### <a name="-keepalived--vrrp--track_process--terminate_delay"></a>`terminate_delay`
+
+Data type: `Optional[Integer[0]]`
+
+time to delay after process quorum lost before consider process down
 
 Default value: `undef`
 

--- a/manifests/vrrp/track_process.pp
+++ b/manifests/vrrp/track_process.pp
@@ -7,7 +7,11 @@
 #
 # @param quorum Number of processes to expect running
 #
-# @param delay Time to delay after process quorum lost before considering process failed (in fractions of second)
+# @param delay this sets fork_delay and terminate_delay (for keepalived => 2.0.16), before terminate_delay
+#
+# @param fork_delay time to delay after process quorum gained after fork before consider process up
+#
+# @param terminate_delay time to delay after process quorum lost before consider process down
 #
 # @param full_command Match entire process cmdline
 #
@@ -18,19 +22,23 @@ define keepalived::vrrp::track_process (
   Optional[Integer[0]] $weight   = undef,
   Integer[0] $quorum             = 1,
   Optional[Integer[0]] $delay    = undef,
+  Optional[Integer[0]] $fork_delay = undef,
+  Optional[Integer[0]] $terminate_delay = undef,
   Boolean $full_command          = false,
   Optional[Enum['initial','partial']] $param_match = undef
 ) {
   concat::fragment { "keepalived.conf_vrrp_track_process_${proc_name}":
     target  => "${keepalived::config_dir}/keepalived.conf",
     content => epp('keepalived/vrrp_track_process.epp', {
-        'name'         => $name,
-        'proc_name'    => $proc_name,
-        'weight'       => $weight,
-        'quorum'       => $quorum,
-        'delay'        => $delay,
-        'full_command' => $full_command,
-        'param_match'  => $param_match
+        'name'            => $name,
+        'proc_name'       => $proc_name,
+        'weight'          => $weight,
+        'quorum'          => $quorum,
+        'delay'           => $delay,
+        'fork_delay'      => $fork_delay,
+        'terminate_delay' => $terminate_delay,
+        'full_command'    => $full_command,
+        'param_match'     => $param_match
     }),
     order   => '020',
   }

--- a/spec/defines/keepalived_vrrp_track_process_spec.rb
+++ b/spec/defines/keepalived_vrrp_track_process_spec.rb
@@ -91,6 +91,42 @@ describe 'keepalived::vrrp::track_process', type: :define do
         }
       end
 
+      describe 'with parameter fork_delay' do
+        let(:params) do
+          {
+            fork_delay: 42,
+            proc_name: '_PROC_NAME_'
+          }
+        end
+
+        it { is_expected.to create_keepalived__vrrp__track_process('_PROC_NAME_') }
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_track_process__PROC_NAME_').with(
+              'content' => %r{fork_delay.*42}
+            )
+        }
+      end
+
+      describe 'with parameter terminate_delay' do
+        let(:params) do
+          {
+            terminate_delay: 84,
+            proc_name: '_PROC_NAME_'
+          }
+        end
+
+        it { is_expected.to create_keepalived__vrrp__track_process('_PROC_NAME_') }
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_track_process__PROC_NAME_').with(
+              'content' => %r{terminate_delay.*84}
+            )
+        }
+      end
+
       describe 'with parameter param_match' do
         let(:params) do
           {

--- a/templates/vrrp_track_process.epp
+++ b/templates/vrrp_track_process.epp
@@ -3,6 +3,8 @@
       Optional[Integer] $weight,
       Optional[Integer] $quorum,
       Optional[Integer] $delay,
+      Optional[Integer] $fork_delay,
+      Optional[Integer] $terminate_delay,
       Optional[String]  $param_match,
       Optional[Boolean] $full_command
     | -%>
@@ -13,6 +15,12 @@ vrrp_track_process <%= $name %> {
   <%- } -%>
   <%- if $quorum { -%>
   quorum      <%= $quorum %>
+  <%- } -%>
+  <%- if $fork_delay { -%>
+  fork_delay       <%= $fork_delay %>
+  <%- } -%>
+  <%- if $terminate_delay { -%>
+  terminate_delay       <%= $terminate_delay %>
   <%- } -%>
   <%- if $delay { -%>
   delay       <%= $delay %>

--- a/types/vrrp/instance/vrule.pp
+++ b/types/vrrp/instance/vrule.pp
@@ -1,5 +1,4 @@
-# @summary keepalived::vrrp::instance::vrule
-# @description Translates directly to rules to be added as per `ip-rule(8)`
+# @summary Translates directly to rules to be added as per `ip-rule(8)`
 type Keepalived::Vrrp::Instance::VRule = Struct[{
     Optional[from]                  => String,
     Optional[to]                    => String,


### PR DESCRIPTION
These seem to be available from keepalived 2.0.16 onwards. Which also changes purpose of the delay parameter to be the default for both.

