### PR TITLE
Avoid messing up fragment ordering if instance name contains dashes

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -241,7 +241,8 @@ define keepalived::vrrp::instance (
   Boolean $use_vmac_addr                                                  = false,
   Boolean $native_ipv6                                                    = false,
 ) {
-  $_name = regsubst($name, '[:\/\n]', '')
+  $_name = regsubst($name, '[:\/\n]', '', 'G')
+  $_ordersafe = regsubst($_name, '-', '', 'G')
   $unicast_peer_array = [$unicast_peers].flatten
   $auth_pass_unsensitive = if $auth_pass =~ Sensitive {
     $auth_pass.unwrap
@@ -252,14 +253,14 @@ define keepalived::vrrp::instance (
   concat::fragment { "keepalived.conf_vrrp_instance_${_name}":
     target  => "${keepalived::config_dir}/keepalived.conf",
     content => template('keepalived/vrrp_instance.erb'),
-    order   => "100-${_name}-000",
+    order   => "100-${_ordersafe}-000",
   }
 
   if size($unicast_peer_array) > 0 or $collect_unicast_peers {
     concat::fragment { "keepalived.conf_vrrp_instance_${_name}_upeers_header":
       target  => "${keepalived::config_dir}/keepalived.conf",
       content => "  unicast_peer {\n",
-      order   => "100-${_name}-010",
+      order   => "100-${_ordersafe}-010",
     }
 
     if $collect_unicast_peers {
@@ -288,13 +289,13 @@ define keepalived::vrrp::instance (
     concat::fragment { "keepalived.conf_vrrp_instance_${_name}_upeers_footer":
       target  => "${keepalived::config_dir}/keepalived.conf",
       content => "  }\n\n",
-      order   => "100-${_name}-030",
+      order   => "100-${_ordersafe}-030",
     }
   }
 
   concat::fragment { "keepalived.conf_vrrp_instance_${_name}_footer":
     target  => "${keepalived::config_dir}/keepalived.conf",
     content => "}\n\n",
-    order   => "100-${_name}-zzz",
+    order   => "100-${_ordersafe}-zzz",
   }
 }

--- a/manifests/vrrp/unicast_peer.pp
+++ b/manifests/vrrp/unicast_peer.pp
@@ -24,11 +24,12 @@ define keepalived::vrrp::unicast_peer (
 ) {
   assert_private()
 
-  $_inst = regsubst($instance, '[:\/\n]', '')
+  $_inst = regsubst($instance, '[:\/\n]', '', 'G')
+  $_ordersafe = regsubst($_inst, '-', '', 'G')
 
   concat::fragment { "keepalived.conf_vrrp_instance_${_inst}_upeers_peer_${ip_address}":
     target  => "${keepalived::config_dir}/keepalived.conf",
     content => "    ${ip_address}\n",
-    order   => "100-${_inst}-020",
+    order   => "100-${_ordersafe}-020",
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

Config fragments are called 100-$NAME-key (Note: parts are separated by dashes). Now if the following conditions are met, ordering will be messed up:
- $NAME contains dashes
- you're trying to set up more than one VRRP instance
- instance names contain unequal amounts of dashes
- one name is a substring of the other

I created another "ordersafe" variable that does not contain dashes. Also I noticed that $_name could still contain colons, slashes, ... because regsubst was just removing the first occurrence. The G flag will fix this, while we're here.

#### This Pull Request (PR) fixes the following issues

Fixes #302