### PR TITLE
Improve collect_unicast_peers

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -250,12 +250,6 @@ define keepalived::vrrp::instance (
     $auth_pass
   }
 
-  concat::fragment { "keepalived.conf_vrrp_instance_${_name}":
-    target  => "${keepalived::config_dir}/keepalived.conf",
-    content => template('keepalived/vrrp_instance.erb'),
-    order   => "100-${_ordersafe}-000",
-  }
-
   if size($unicast_peer_array) > 0 or $collect_unicast_peers {
     concat::fragment { "keepalived.conf_vrrp_instance_${_name}_upeers_header":
       target  => "${keepalived::config_dir}/keepalived.conf",
@@ -291,6 +285,12 @@ define keepalived::vrrp::instance (
       content => "  }\n\n",
       order   => "100-${_ordersafe}-030",
     }
+  }
+
+  concat::fragment { "keepalived.conf_vrrp_instance_${_name}":
+    target  => "${keepalived::config_dir}/keepalived.conf",
+    content => template('keepalived/vrrp_instance.erb'),
+    order   => "100-${_ordersafe}-000",
   }
 
   concat::fragment { "keepalived.conf_vrrp_instance_${_name}_footer":

--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -274,7 +274,7 @@ define keepalived::vrrp::instance (
         instance   => $name,
         ip_address => $unicast_src,
       }
-      Keepalived::Vrrp::Unicast_peer <<| instance == $name and title != $unicast_src |>>
+      Keepalived::Vrrp::Unicast_peer <<| instance == $name and ip_address != $unicast_src |>>
     }
 
     if size($unicast_peer_array) > 0 {

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -224,4 +224,7 @@ vrrp_instance <%= @_name %> {
   <%- if @unicast_source_ip -%>
 
   unicast_src_ip <%= @unicast_source_ip %>
+  <%- elsif @unicast_src -%>
+
+  unicast_src_ip <%= @unicast_src %>
   <%- end -%>


### PR DESCRIPTION
#### Pull Request (PR) description

As described in #304, collect_unicast_peers will add the local source IP to the list of unicast_peers. Currently this is a rather cosmetic problem, but it may confuse someone unfamiliar with the module who's looking at the configuration file.
Also, the ideal contents for unicast_src_ip which will match the rest of the configuration is determined by the module, but it is never explicitly added to it. Instead we're relying on Keepalived to come to the same result. I added it to the template (still overridable by setting unicast_source_ip explicitly) and moved it's fragment below "if $collect_unicast_peers" for this to work.

#### This Pull Request (PR) fixes the following issues

Fixes #304 