### PR TITLE
vrrp_instance::track_script: Fix Datatype-Mismatch

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1197,7 +1197,9 @@ Default value: `undef`
 
 Data type: `Variant[Array[String[1]],String[1]]`
 
-Define which script to run to track service states.
+Define which scripts to run to track service states.
+May be specified either as a String with a single Scriptname,
+or as an Array of Strings with multiple Scriptnames.
 
 Default value: `[]`
 

--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -81,7 +81,9 @@
 #   Authentication password.
 #
 # @param track_script
-#   Define which script to run to track service states.
+#   Define which scripts to run to track service states.
+#   May be specified either as a String with a single Scriptname,
+#   or as an Array of Strings with multiple Scriptnames.
 #
 # @param track_process
 #   Define which process trackers to run.

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -353,10 +353,27 @@ describe 'keepalived::vrrp::instance', type: :define do
         }
       end
 
-      describe 'with parameter track_script' do
+      describe 'with parameter track_script as an Array of Strings' do
         let(:params) do
           mandatory_params.merge(
             track_script: ['_VALUE_']
+          )
+        end
+
+        it { is_expected.to create_keepalived__vrrp__instance('_NAME_') }
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+              'content' => %r!^  track_script {\n    _VALUE_!
+            )
+        }
+      end
+
+      describe 'with parameter track_script as a single String' do
+        let(:params) do
+          mandatory_params.merge(
+            track_script: '_VALUE_'
           )
         end
 

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -100,7 +100,7 @@ vrrp_instance <%= @_name %> {
   <%- unless @track_script.empty? -%>
 
   track_script {
-  <%- @track_script.each do |track| -%>
+  <%- Array(@track_script).flatten.each do |track| -%>
     <%= track %>
   <%- end -%>
   }


### PR DESCRIPTION
#### Pull Request (PR) description
The Variant of `$track_script`'s Datatype
```
Variant[Array[String[1]],String[1]] $track_script
```

has to get handled correctly in the ERB-File.  Otherwise it fails with a single String.

#### This Pull Request (PR) fixes the following issues
fixes 4307d70f04396dc9d0316d0b52e0acc30c8b1ddf
