### PR TITLE
service: hasrestart/hasstatus: use Puppet defaults

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -177,17 +177,19 @@ Default value: `'running'`
 
 ##### <a name="-keepalived--service_hasrestart"></a>`service_hasrestart`
 
-Data type: `Boolean`
+Data type: `Optional[Boolean]`
 
 
+
+Default value: `undef`
 
 ##### <a name="-keepalived--service_hasstatus"></a>`service_hasstatus`
 
-Data type: `Boolean`
+Data type: `Optional[Boolean]`
 
 
 
-Default value: `true`
+Default value: `undef`
 
 ##### <a name="-keepalived--service_manage"></a>`service_manage`
 

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,4 +1,3 @@
 ---
 keepalived::sysconf_dir: 'default'
 keepalived::sysconf_options: ''
-keepalived::service_hasrestart: false

--- a/data/os/Gentoo.yaml
+++ b/data/os/Gentoo.yaml
@@ -1,4 +1,3 @@
 ---
 keepalived::sysconf_dir: 'conf.d'
 keepalived::sysconf_options: '-D'
-keepalived::service_hasrestart: false

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,4 +1,3 @@
 ---
 keepalived::sysconf_dir: 'sysconfig'
 keepalived::sysconf_options: '-D'
-keepalived::service_hasrestart: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,8 +56,8 @@
 class keepalived (
   String[1] $sysconf_dir,
   String    $sysconf_options,
-  Boolean   $service_hasrestart,
-  Boolean   $service_hasstatus = true,
+  Optional[Boolean] $service_hasrestart = undef,
+  Optional[Boolean] $service_hasstatus = undef,
 
   Stdlib::Absolutepath $config_dir       = '/etc/keepalived',
   Stdlib::Filemode     $config_dir_mode  = '0755',

--- a/spec/classes/keepalived_spec.rb
+++ b/spec/classes/keepalived_spec.rb
@@ -29,26 +29,12 @@ describe 'keepalived', type: :class do
           )
         }
 
-        case facts[:osfamily]
-        when 'Debian'
-          it {
-            is_expected.to contain_service('keepalived').with(
-              'ensure' => 'running',
-              'enable' => 'true',
-              'hasrestart' => 'false',
-              'hasstatus' => 'true'
-            )
-          }
-        else
-          it {
-            is_expected.to contain_service('keepalived').with(
-              'ensure' => 'running',
-              'enable' => 'true',
-              'hasrestart' => 'true',
-              'hasstatus' => 'true'
-            )
-          }
-        end
+        it {
+          is_expected.to contain_service('keepalived').with(
+            'ensure' => 'running',
+            'enable' => 'true'
+          )
+        }
       end
 
       describe 'with parameter: config_dir' do


### PR DESCRIPTION
This is a followup of 86b83d3bb245d212a14afa8a4ae9bf31db50761d. We don't need to explicitly set hasrestart to false/true. All systems run systemd and the units have a working restart option so we can use it. And instead of hardcoding this we can just set it to undef so puppet figures this out on its own.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
