### PR TITLE
Allow Sensitive `$auth_pass`

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -287,9 +287,14 @@ define keepalived::vrrp::instance (
     }
   }
 
+  $_content = if $auth_pass =~ Sensitive {
+    Sensitive(template('keepalived/vrrp_instance.erb'))
+  } else {
+    template('keepalived/vrrp_instance.erb')
+  }
   concat::fragment { "keepalived.conf_vrrp_instance_${_name}":
     target  => "${keepalived::config_dir}/keepalived.conf",
-    content => template('keepalived/vrrp_instance.erb'),
+    content => $_content,
     order   => "100-${_ordersafe}-000",
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.1.0 < 10.0.0"
+      "version_requirement": ">= 7.4.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -348,7 +348,7 @@ describe 'keepalived::vrrp::instance', type: :define do
         it {
           is_expected.to \
             contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
-              'content' => %r{auth_pass.*_VALUE_}
+              'content' => sensitive(%r{auth_pass.*_VALUE_})
             )
         }
       end


### PR DESCRIPTION
#### Pull Request (PR) description
To not reveal sensitive Data with the Variable `$auth_pass`, the rendered Template gets wrapped as Datatype `Sensitive`.

#### This Pull Request (PR) fixes the following issues
To not reveal sensitive Data with the Variable `$auth_pass`, the rendered Template gets wrapped as Datatype `Sensitive`.  
Fixes #338 