### PR TITLE
allow hiera to define keepalived::global_defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,33 @@ class { 'keepalived::global_defs':
   vrrp_notify_fifo_script => 'your_fifo_script_path',
 }
 ```
+or hiera:
 
+```yaml
+---
+keepalived::global_defs:
+  notification_email: 'no@spam.tld'
+  notification_email_from: 'no@spam.tld'
+  smtp_server: 'localhost'
+  smtp_connect_timeout: '60'
+  router_id: 'your_router_instance_id'
+  bfd_rlimit_rttime: 10000
+  checker_rlimit_rttime: 10000
+  vrrp_rlimit_rttime: 10000
+  bfd_priority: -20
+  checker_priority: -20
+  vrrp_priority: -20
+  bfd_rt_priority: 50
+  checker_rt_priority: 50
+  vrrp_rt_priority: 50
+  bfd_no_swap: true
+  checker_no_swap: true
+  vrrp_no_swap: true
+  vrrp_version: 3
+  max_auto_priority: 99
+  vrrp_notify_fifo: '/run/keepalived.fifo'
+  vrrp_notify_fifo_script: 'your_fifo_script_path'
+```
 ### Soft-restart the Keepalived daemon
 
 ```puppet

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -66,6 +66,7 @@ The following parameters are available in the `keepalived` class:
 * [`service_manage`](#-keepalived--service_manage)
 * [`service_name`](#-keepalived--service_name)
 * [`service_restart`](#-keepalived--service_restart)
+* [`global_defs`](#-keepalived--global_defs)
 * [`vrrp_instance`](#-keepalived--vrrp_instance)
 * [`vrrp_script`](#-keepalived--vrrp_script)
 * [`vrrp_track_process`](#-keepalived--vrrp_track_process)
@@ -210,6 +211,14 @@ Default value: `'keepalived'`
 ##### <a name="-keepalived--service_restart"></a>`service_restart`
 
 Data type: `Optional[String[1]]`
+
+
+
+Default value: `undef`
+
+##### <a name="-keepalived--global_defs"></a>`global_defs`
+
+Data type: `Optional[Hash]`
 
 
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,6 +42,12 @@ class keepalived::config {
     order   => '001',
   }
 
+  if $keepalived::global_defs {
+    class { 'keepalived::global_defs':
+      * => $keepalived::global_defs,
+    }
+  }
+
   concat::fragment { 'keepalived.conf_include_external_configs':
     target  => "${keepalived::config_dir}/keepalived.conf",
     content => epp('keepalived/include-external-configs.epp',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,8 @@
 #
 # @param service_restart
 #
+# @param global_defs
+#
 # @param vrrp_instance
 #
 # @param vrrp_script
@@ -81,12 +83,13 @@ class keepalived (
 
   Boolean                 $manage_package     = true,
 
-  Hash $vrrp_instance      = {},
-  Hash $vrrp_script        = {},
-  Hash $vrrp_track_process = {},
-  Hash $vrrp_sync_group    = {},
-  Hash $lvs_real_server    = {},
-  Hash $lvs_virtual_server = {},
+  Optional[Hash] $global_defs = undef,
+  Hash $vrrp_instance         = {},
+  Hash $vrrp_script           = {},
+  Hash $vrrp_track_process    = {},
+  Hash $vrrp_sync_group       = {},
+  Hash $lvs_real_server       = {},
+  Hash $lvs_virtual_server    = {},
 ) {
   contain keepalived::install
   contain keepalived::config

--- a/spec/classes/keepalived_spec.rb
+++ b/spec/classes/keepalived_spec.rb
@@ -168,6 +168,17 @@ describe 'keepalived', type: :class do
           )
         }
       end
+
+      describe 'with parameter: global_defs' do
+        let(:params) { { global_defs: { enable_script_security: 'true' } } }
+
+        it {
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_globaldefs').with(
+              'content' => %r{enable_script_security$}
+            )
+        }
+      end
     end
   end
 end


### PR DESCRIPTION


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
allow hiera to define keepalived::global_defs

add global_defs parameter to init.pp
add class keepalived::global_defs if $keepalived::global_defs is defined


#### This Pull Request (PR) fixes the following issues
n/a

