### PR TITLE
Add `validate_cmd` for `keepalived.conf`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -54,6 +54,7 @@ The following parameters are available in the `keepalived` class:
 * [`config_dir`](#-keepalived--config_dir)
 * [`config_dir_mode`](#-keepalived--config_dir_mode)
 * [`config_file_mode`](#-keepalived--config_file_mode)
+* [`config_validate_cmd`](#-keepalived--config_validate_cmd)
 * [`config_group`](#-keepalived--config_group)
 * [`config_owner`](#-keepalived--config_owner)
 * [`daemon_group`](#-keepalived--daemon_group)
@@ -112,6 +113,14 @@ Data type: `Stdlib::Filemode`
 
 
 Default value: `'0644'`
+
+##### <a name="-keepalived--config_validate_cmd"></a>`config_validate_cmd`
+
+Data type: `Variant[String, Undef]`
+
+Input for the `validate_cmd` param of the keepalived.conf concat fragment.
+
+Default value: `'/usr/sbin/keepalived -l -t -f %'`
 
 ##### <a name="-keepalived--config_group"></a>`config_group`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,9 +31,10 @@ class keepalived::config {
   }
 
   concat { "${keepalived::config_dir}/keepalived.conf":
-    owner => $keepalived::config_owner,
-    group => $keepalived::config_group,
-    mode  => $keepalived::config_file_mode,
+    owner        => $keepalived::config_owner,
+    group        => $keepalived::config_group,
+    mode         => $keepalived::config_file_mode,
+    validate_cmd => $keepalived::config_validate_cmd,
   }
 
   concat::fragment { 'keepalived.conf_header':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,8 @@
 #
 # @param config_file_mode
 #
+# @param config_validate_cmd Input for the `validate_cmd` param of the keepalived.conf concat fragment.
+#
 # @param config_group
 #
 # @param config_owner
@@ -61,9 +63,10 @@ class keepalived (
   Optional[Boolean] $service_hasrestart = undef,
   Optional[Boolean] $service_hasstatus = undef,
 
-  Stdlib::Absolutepath $config_dir       = '/etc/keepalived',
-  Stdlib::Filemode     $config_dir_mode  = '0755',
-  Stdlib::Filemode     $config_file_mode = '0644',
+  Stdlib::Absolutepath   $config_dir          = '/etc/keepalived',
+  Stdlib::Filemode       $config_dir_mode     = '0755',
+  Stdlib::Filemode       $config_file_mode    = '0644',
+  Variant[String, Undef] $config_validate_cmd = '/usr/sbin/keepalived -l -t -f %',
 
   Array[Stdlib::Absolutepath] $include_external_conf_files = [],
 

--- a/spec/classes/keepalived_spec.rb
+++ b/spec/classes/keepalived_spec.rb
@@ -23,9 +23,10 @@ describe 'keepalived', type: :class do
 
         it {
           is_expected.to contain_concat('/etc/keepalived/keepalived.conf').with(
-            'group' => 'root',
-            'mode' => '0644',
-            'owner' => 'root'
+            'group'        => 'root',
+            'mode'         => '0644',
+            'owner'        => 'root',
+            'validate_cmd' => '/usr/sbin/keepalived -l -t -f %'
           )
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description

I added a new overridable param called `config_validate_cmd`. It is used as input for the validate_cmd param of the keepalived.conf concat fragment. This should catch broken configs in the future.

#### This Pull Request (PR) fixes the following issues

Fixes #345