### PR TITLE
allow setting process parameters for `track_process`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1776,9 +1776,11 @@ The following parameters are available in the `keepalived::vrrp::track_process` 
 
 ##### <a name="-keepalived--vrrp--track_process--proc_name"></a>`proc_name`
 
-Data type: `String[1]`
+Data type: `Variant[String[1], Array[String[1],1]]`
 
 process name to track
+use an Array configuration to specify process parameters (first element needs to
+be the process name).
 
 ##### <a name="-keepalived--vrrp--track_process--weight"></a>`weight`
 

--- a/manifests/vrrp/track_process.pp
+++ b/manifests/vrrp/track_process.pp
@@ -30,7 +30,7 @@ define keepalived::vrrp::track_process (
   Boolean $full_command          = false,
   Optional[Enum['initial','partial']] $param_match = undef
 ) {
-  concat::fragment { "keepalived.conf_vrrp_track_process_${proc_name}":
+  concat::fragment { "keepalived.conf_vrrp_track_process_${name}":
     target  => "${keepalived::config_dir}/keepalived.conf",
     content => epp('keepalived/vrrp_track_process.epp', {
         'name'            => $name,

--- a/manifests/vrrp/track_process.pp
+++ b/manifests/vrrp/track_process.pp
@@ -1,7 +1,10 @@
 #
 # @summary Configure the process tracker
 #
-# @param proc_name process name to track
+# @param proc_name 
+#   process name to track
+#   use an Array configuration to specify process parameters (first element needs to
+#   be the process name).
 #
 # @param weight The weight that should add to the instance.
 #
@@ -18,7 +21,7 @@
 # @param param_match  Set inital if command has no parameters or use partial if first n parameters match
 #
 define keepalived::vrrp::track_process (
-  String[1] $proc_name,
+  Variant[String[1], Array[String[1],1]] $proc_name,
   Optional[Integer[0]] $weight   = undef,
   Integer[0] $quorum             = 1,
   Optional[Integer[0]] $delay    = undef,

--- a/spec/defines/keepalived_vrrp_track_process_spec.rb
+++ b/spec/defines/keepalived_vrrp_track_process_spec.rb
@@ -37,6 +37,23 @@ describe 'keepalived::vrrp::track_process', type: :define do
         end
       end
 
+      describe 'with array parameter proc_name' do
+        let(:params) do
+          {
+            proc_name: ['MYPROCNAME', 'PARAM 1']
+          }
+        end
+
+        it { is_expected.to create_keepalived__vrrp__track_process('_PROC_NAME_') }
+
+        it do
+          is_expected.to \
+            contain_concat__fragment('keepalived.conf_vrrp_track_process__PROC_NAME_').with(
+              'content' => %r{process.*MYPROCNAME.*PARAM 1}
+            )
+        end
+      end
+
       describe 'with parameter weight' do
         let(:params) do
           {

--- a/templates/vrrp_track_process.epp
+++ b/templates/vrrp_track_process.epp
@@ -1,5 +1,5 @@
 <%- | String $name,
-      String $proc_name,
+      Variant[String[1], Array[String[1],1]] $proc_name,
       Optional[Integer] $weight,
       Optional[Integer] $quorum,
       Optional[Integer] $delay,
@@ -9,7 +9,11 @@
       Optional[Boolean] $full_command
     | -%>
 vrrp_track_process <%= $name %> {
+  <%- if $proc_name =~ String { -%>
   process     "<%= $proc_name %>"
+  <%- } else { -%>
+  process     "<%= $proc_name.join('" "') %>"
+  <%- } -%>
   <%- if $weight { -%>
   weight      <%= $weight %>
   <%- } -%>


### PR DESCRIPTION
With this, setting parameter to check for vrrp processes is possible.
