### PR TITLE
snmp: Only configure snmp_socket when it is required

### DIFF
--- a/spec/classes/keepalived_global_defs_spec.rb
+++ b/spec/classes/keepalived_global_defs_spec.rb
@@ -12,6 +12,7 @@ describe 'keepalived::global_defs', type: :class do
 
       describe 'without parameters' do
         it { is_expected.to create_class('keepalived::global_defs') }
+        it { is_expected.to contain_concat__fragment('keepalived.conf_globaldefs').without('content' => %(snmp_socket)) }
       end
 
       describe 'with parameter notification_email as string' do
@@ -377,7 +378,8 @@ describe 'keepalived::global_defs', type: :class do
       describe 'with parameter snmp_socket' do
         let(:params) do
           {
-            snmp_socket: '/path'
+            snmp_socket: '/path',
+            enable_snmp_vrrp: true
           }
         end
 

--- a/templates/globaldefs.erb
+++ b/templates/globaldefs.erb
@@ -123,7 +123,7 @@ global_defs {
   <%- if @dynamic_interfaces -%>
   dynamic_interfaces
   <%- end -%>
-  <%- if @snmp_socket -%>
+  <%- if @snmp_socket && (@enable_snmp_keepalived || @enable_snmp_vrrp || @enable_snmp_checker || @enable_snmp_rfc || @enable_snmp_rfcv2 || @enable_snmp_rfcv3) -%>
   snmp_socket <%= @snmp_socket %>
   <%- end -%>
   <%- if @vrrp_notify_fifo -%>


### PR DESCRIPTION
The easier option would be to switch snmp_socket to undef by default, but that would be a breaking change.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
