### PR TITLE
config_validate_cmd: Switch datatype to absolute path

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -116,7 +116,7 @@ Default value: `'0644'`
 
 ##### <a name="-keepalived--config_validate_cmd"></a>`config_validate_cmd`
 
-Data type: `Variant[String, Undef]`
+Data type: `Stdlib::Absolutepath`
 
 Input for the `validate_cmd` param of the keepalived.conf concat fragment.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,7 +66,7 @@ class keepalived (
   Stdlib::Absolutepath   $config_dir          = '/etc/keepalived',
   Stdlib::Filemode       $config_dir_mode     = '0755',
   Stdlib::Filemode       $config_file_mode    = '0644',
-  Variant[String, Undef] $config_validate_cmd = '/usr/sbin/keepalived -l -t -f %',
+  Stdlib::Absolutepath   $config_validate_cmd = '/usr/sbin/keepalived -l -t -f %',
 
   Array[Stdlib::Absolutepath] $include_external_conf_files = [],
 


### PR DESCRIPTION
Optional doesn't make sense here because we cannot pass undef when the parameter has a default value. And the resources require an absolute path.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
